### PR TITLE
Instances list

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -4,19 +4,176 @@
               "clearnet": "https://search.ahwx.org",
               "tor": "http://hyy7rcvknwb22v4nnoar635wntiwr4uwzhiuyimemyl4fz6k7tahj5id.onion",
               "i2p": null,
-              "country": "FR"
+              "country": "FR",
+              "librey": true
           },
           {
               "clearnet": "https://librex.me",
               "tor": "librex.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion",
               "i2p": "revekebotog64xrrammtsmjwtwlg3vqyzwdurzt2pu6botg4bejq.b32.i2p",
-              "country": "CA"
+              "country": "CA",
+              "librey": true
           },
           {
               "clearnet": "https://librex.revvy.de",
               "tor": "librex.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion",
               "i2p": "revekebotog64xrrammtsmjwtwlg3vqyzwdurzt2pu6botg4bejq.b32.i2p",
-              "country": "CA"
+              "country": "CA",
+              "librey": true
           },
+          {
+              "clearnet": "https://search.davidovski.xyz/",
+              "tor": null,
+              "i2p": null,
+              "country": "GB",
+              "librey": true
+          },
+          {
+              "clearnet": "https://librex.zzls.xyz/",
+              "tor": "http://librex.zzlsghu6mvvwyy75mvga6gaf4znbp3erk5xwfzedb4gg6qqh2j6rlvid.onion/",
+              "i2p": "http://zzlsaymhcfla7vibo3a223bybeecu3bd5z6rmw2u4y76maqeu76q.b32.i2p/",
+              "country": "CL",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.me/",
+              "tor": "http://librex.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion/",
+              "i2p": "http://revekebotog64xrrammtsmjwtwlg3vqyzwdurzt2pu6botg4bejq.b32.i2p/",
+              "country": "CA",
+              "librey": false
+          },
+          {
+              "clearnet": "https://s.dyox.in/",
+              "tor": "http://ddhigxwjz7elcl2erm7qzzukda4qmovoy4cepcueahggpwrpu24mi6qd.onion/",
+              "i2p": "http://s.dyoxin.i2p/",
+              "country": "IS",
+              "librey": false
+          },
+          {
+              "clearnet": "https://lx.vern.cc/",
+              "tor": "http://lx.vernccvbvyi5qhfzyqengccj7lkove6bjot2xhh5kajhwvidqafczrad.onion/",
+              "i2p": "http://vernziqfqvweijfaacmwazohgpdo2bt2ib2jlupt2pwwu27bhgxq.b32.i2p/",
+              "country": "US",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.ahwx.org/",
+              "tor": "http://cosrpybbddzdfjquer3zfmb2h5avtacnctnbu4gucwocdb42s63gcqqd.onion/",
+              "i2p": null,
+              "country": "NL",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.spaceint.fr/",
+              "tor": "http://6d4nqt2rndvmhogpwrbqfvj2ur6e6nm2r6dzi7ny4wj6ai3j5hnvbhyd.onion/",
+              "i2p": null,
+              "country": "FR",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.madreyk.xyz/",
+              "tor": null,
+              "i2p": null,
+              "country": "DE",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.pabloferreiro.es/",
+              "tor": null,
+              "i2p": null,
+              "country": "DE",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.pufe.org/",
+              "tor": null,
+              "i2p": null,
+              "country": "NZ",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.ratakor.com/",
+              "tor": null,
+              "i2p": null,
+              "country": "FR",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.tildevarsh.in/",
+              "tor": null,
+              "i2p": null,
+              "country": "IN",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.myroware.eu/",
+              "tor": null,
+              "i2p": null,
+              "country": "DE",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.bloatcat.tk/",
+              "tor": null,
+              "i2p": null,
+              "country": "IS",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.retro-hax.net/",
+              "tor": null,
+              "i2p": null,
+              "country": "DE",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.funami.tech/",
+              "tor": null,
+              "i2p": null,
+              "country": "KR",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.zeroish.xyz/",
+              "tor": null,
+              "i2p": null,
+              "country": "US",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.baczek.me/",
+              "tor": null,
+              "i2p": null,
+              "country": "PL",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.yogeshlamichhane.com.np/",
+              "tor": null,
+              "i2p": null,
+              "country": "US",
+              "librey": false
+          },
+          {
+              "clearnet": "https://lx.benike.monster/",
+              "tor": null,
+              "i2p": null,
+              "country": "DE",
+              "librey": false
+          },
+          {
+              "clearnet": "https://librex.nohost.network/",
+              "tor": null,
+              "i2p": null,
+              "country": "MX",
+              "librey": false
+          },
+          {
+              "clearnet": "https://search.decentrala.org/",
+              "tor": null,
+              "i2p": null,
+              "country": "US",
+              "librey": false
+          }
     ]
 }

--- a/instances.php
+++ b/instances.php
@@ -1,0 +1,61 @@
+<?php 
+    require "misc/header.php";
+    require "misc/tools.php";
+            
+    $instances_json = json_decode(file_get_contents("instances.json"), true);
+
+    $librey_instances = array_filter($instances_json['instances'], fn($n) => $n['librey']);
+    $librex_instances = array_filter($instances_json['instances'], fn($n) => !$n['librey']);
+
+
+    function list_instances($instances) 
+    {
+        echo "<table><tr>";
+        echo "<th>Clearnet</th>";
+        echo "<th>Tor</th>";
+        echo "<th>I2P</th>";
+        echo "<th>Country</th>";
+        echo "</tr>";
+
+        foreach($instances as $instance) {
+            $hostname = parse_url($instance["clearnet"])["host"];
+            $country = get_country_emote($instance["country"]) . $instnace["country"];
+
+            $is_tor = !is_null($instance["tor"]);
+            $is_i2p = !is_null($instance["i2p"]);
+
+            echo "<tr>";
+            echo "<td><a href=\"" . $instance["clearnet"] . "\">" . $hostname . "</a></td>";
+
+            echo $is_tor
+                ? "<td><a href=\"" . $instance["tor"] . "\">\u{2705}</a></td>"
+                : "<td>\u{274C}</td>";
+
+            echo $is_i2p
+                ? "<td><a href=\"" . $instance["i2p"] . "\">\u{2705}</a></td>"
+                :"<td>\u{274C}</td>";
+
+            echo "<td>$country</td>";
+            echo "</tr>";
+        }
+        echo "</table>";
+    }
+?>
+    <title>LibreY - instances</title>
+    </head>
+    <body>
+        
+        <center>
+            <h2>Libre<span class="Y">Y</span> instances</h2>
+            <?php
+                list_instances($librey_instances);
+            ?>
+
+            <p>The following instnaces are running the older <a href="https://github.com/hnhx/librex">LibreX</a>:</p>
+            <?php
+                list_instances($librex_instances);
+            ?>
+        </center>
+    
+
+<?php require "misc/footer.php"; ?>

--- a/misc/footer.php
+++ b/misc/footer.php
@@ -1,6 +1,7 @@
 <div class="footer-container">
     <a href="./">LibreY</a>
-    <a href="https://github.com/Ahwxorg/librey/" target="_blank">Source &amp; Instances</a>
+    <a href="https://github.com/Ahwxorg/librey/" target="_blank">Source</a>
+    <a href="./instances.php" target="_blank">Instances</a>
     <a href="./settings.php">Settings</a>
     <a href="./api.php" target="_blank">API</a>
     <a href="./donate.php">Donate ❤️</a>

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -237,4 +237,20 @@
             curl_setopt( $curl, CURLOPT_COOKIE, $_SERVER['HTTP_COOKIE'] );
     }
 
+    
+    function get_country_emote($code)
+    {
+        $emoji = [];
+        foreach(str_split($code) as $c) {
+            if(($o = ord($c)) > 64 && $o % 32 < 27) {
+                $emoji[] = hex2bin("f09f87" . dechex($o % 32 + 165));
+                continue;
+            }
+            
+            $emoji[] = $c;
+        }
+
+        return join($emoji);
+    }
+
 ?>


### PR DESCRIPTION
pr proposal for #5 

move instances list to `instances.php`, automatically generated from `instances.json`

add librex instances to `instances.json` with a flag so that they can be listed separately. (so they can still be used for fallback when google fails)

maybe todo: add css `instances.php` to make it look a little nicer.

