### PR TITLE
Did you mean?

### DIFF
--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -173,7 +173,7 @@
         {
             $didyoumean = $special["did_you_mean"];
             $new_url = "/search.php?q="  . urlencode($didyoumean);
-            echo "<p class\"did-you-mean\">Did you mean ";
+            echo "<p class=\"did-you-mean\">Did you mean ";
             echo "<a href=\"$new_url\">$didyoumean</a>";
             echo "?</p>";
         }

--- a/search.php
+++ b/search.php
@@ -63,6 +63,8 @@
             {
                 case 0:
 					$engine=$config->preferred_engines['text'];
+                    if (is_null($engine))
+                        $engine = "google";
                     $query_parts = explode(" ", $query);
                     $last_word_query = end($query_parts);
                     if (substr($query, 0, 1) == "!" || substr($last_word_query, 0, 1) == "!")

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -30,6 +30,7 @@ a,
 
 .text-result-wrapper a:visited h2,
 .special-result-container a,
+.did-you-mean a,
 .sub-search-button-wrapper a,
 .sub-search-button-wrapper a:visited{
     color: #bd93f9;
@@ -187,7 +188,8 @@ a:hover,
 
 .text-result-container,
 #time,
-.next-page-button-wrapper {
+.next-page-button-wrapper,
+.did-you-mean {
     margin-left: 170px;
 }
 


### PR DESCRIPTION
This PR re-adds the "did you mean" prompt from google search results. Previously, when searching for a similar term google would return results for what it thought you meant, prompting you to "search instead for". This was not reflected in LibreX and made it impossible to search for certain queries

In this PR, the google option nfpr is added, defaulting to showing results for the given query and giving a "did you mean?" if it thinks you meant something different. The value of the "did you mean" search is now added to the top of the results page and as an item in the api also. 
