### PR TITLE
Fix passing quotation marks to google searches

### DIFF
--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -4,7 +4,7 @@
         global $config;
 
         $mh = curl_multi_init();
-        $query_encoded = urlencode($query);
+        $query_encoded = str_replace("%22", "\"", urlencode($query));
         $results = array();
 
         $domain = $config->google_domain;
@@ -13,6 +13,7 @@
         $number_of_results = isset($_COOKIE["google_number_of_results"]) ? trim(htmlspecialchars($_COOKIE["google_number_of_results"])) : $config->google_number_of_results;
 
         $url = "https://www.google.$domain/search?q=$query_encoded&nfpr=1&start=$page";
+        error_log($url);
 
         if (3 > strlen($site_language) && 0 < strlen($site_language))
             $url .= "&hl=$site_language";

--- a/search.php
+++ b/search.php
@@ -7,7 +7,7 @@
 
 <title>
 <?php
-  $query = htmlspecialchars(trim($_REQUEST["q"]));
+  $query = trim($_REQUEST["q"]);
   echo $query;
 ?> - LibreY</title>
 </head>
@@ -24,7 +24,7 @@
                         die();
                     }
 
-                    echo "value=\"$query\"";
+                    echo "value=\"" . htmlspecialchars($query) . "\"";
                 ?>
             >
             <br>


### PR DESCRIPTION
Previously librex would not work correctly when using quotation marks in search queries, since the quotation marks were being encoded as html `&quot;`. This PR ensures that quotations marks are passed to the google search query. 

Example: 
![Example](https://files.davidovski.xyz/u/sx5QdG.png)
Not the best example, but as you can see the search results are different and are inline with the search results that google would give with these exact queries.