### PR TITLE
Fix Gateway Timeout on fallback

### DIFF
--- a/api.php
+++ b/api.php
@@ -26,7 +26,10 @@
     switch ($type)
     {
         case 0:
-            require "engines/google/text.php";
+            $engine=$config->preferred_engines['text'];
+            if (is_null($engine))
+                $engine = "google";
+            require "engines/$engine/text.php";
             $results = get_text_results($query, $page);
             break;
         case 1:

--- a/engines/duckduckgo/text.php
+++ b/engines/duckduckgo/text.php
@@ -72,6 +72,13 @@
             curl_multi_exec($mh, $running);
         } while ($running);
 
+        if (curl_getinfo($google_ch)['http_code'] != '200') 
+        {
+            require "engines/librex/text.php";
+            return get_librex_results($query, $page);
+        }
+
+
 
         if ($special_search != 0)
         {

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -169,6 +169,9 @@
     function print_text_results($results)
     {
 
+        if (empty($results))
+            return;
+
         $special = $results[0];
 
         if (array_key_exists("did_you_mean", $special)) 

--- a/engines/librex/text.php
+++ b/engines/librex/text.php
@@ -4,6 +4,9 @@
     {
         global $config;
 
+        if (isset($_REQUEST["nfb"]) && $_REQUEST["nfb"] == "1")
+            return array();
+
         if (!$config->instance_fallback) 
             return array();
 
@@ -33,7 +36,7 @@
             if (parse_url($instance)["host"] == parse_url($_SERVER['HTTP_HOST'])["host"])
                 continue;
 
-            $url = $instance . "api.php?q=$query_encoded&p=$page&t=0";
+            $url = $instance . "api.php?q=$query_encoded&p=$page&t=0&nfb=1";
 
             $librex_ch = curl_init($url);
             curl_setopt_array($librex_ch, $config->curl_settings);

--- a/engines/librex/text.php
+++ b/engines/librex/text.php
@@ -32,8 +32,6 @@
             if (parse_url($instance)["host"] == parse_url($_SERVER['HTTP_HOST'])["host"])
                 continue;
 
-            error_log("trying to call instance $instance");
-
             $url = $instance . "api.php?q=$query_encoded&p=$page&t=0&nfb=1";
 
             $librex_ch = curl_init($url);

--- a/engines/librex/text.php
+++ b/engines/librex/text.php
@@ -27,14 +27,12 @@
         do {
             $tries++;
 
-            // after "too many" requests, give up
-            if ($tries > 5)
-                return array();
-
             $instance = array_pop($instances);
 
             if (parse_url($instance)["host"] == parse_url($_SERVER['HTTP_HOST'])["host"])
                 continue;
+
+            error_log("trying to call instance $instance");
 
             $url = $instance . "api.php?q=$query_encoded&p=$page&t=0&nfb=1";
 
@@ -47,7 +45,10 @@
             $code = curl_getinfo($librex_ch)["http_code"];
             $results = json_decode($response, true);
 
-        } while ( $results == null || count($results) <= 1);
+        } while ( !empty($instances) && ($results == null || count($results) <= 1));
+
+        if (empty($instances))
+            return array();
 
         return array_values($results);
     }


### PR DESCRIPTION
This is a draft PR for trying to fix #15 and other changes to optimise instance fallback.
The main solution will be to not fallback when being called by an instance trying to fallback already, that way each request that the original instance makes should take roughly the same amount of time and removing the possibility that a fallback loop occurs. 