### PR TITLE
Start building docker images from the repo on ghcr

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,30 @@
+name: Docker Image CI
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: docker/login-action@v2.1.0
+      with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+    - id: owner
+      uses: ASzc/change-string-case-action@v5
+      with:
+          string: ${{ github.repository_owner }}
+    - id: repo
+      uses: ASzc/change-string-case-action@v5
+      with:
+          string: ${{ github.event.repository.name }}
+    - uses: docker/build-push-action@v4
+      with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.owner.outputs.lowercase }}/${{ steps.repo.outputs.lowercase }}:latest


### PR DESCRIPTION
This should build a docker image from whatever is currently in the repo. Tested with latest code from LibreX, that worked flawlessly. LibreY seems to have issues with this approach, I will investigate further.