### PR TITLE
ci: multi-arch docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,10 +22,14 @@ jobs:
       uses: ASzc/change-string-case-action@v5
       with:
           string: ${{ github.event.repository.name }}
+
+    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-buildx-action@v2
     - uses: docker/build-push-action@v4
       with:
           context: .
           file: Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ steps.owner.outputs.lowercase }}/${{ steps.repo.outputs.lowercase }}:latest


### PR DESCRIPTION
Adding support to build arm64 images, which makes this possible to deploy on Raspberry Pi etc.

Based on https://docs.docker.com/build/ci/github-actions/multi-platform/