### PR TITLE
Moving logic to printing results

### DIFF
--- a/engines/ahmia/hidden_service.php
+++ b/engines/ahmia/hidden_service.php
@@ -32,8 +32,8 @@
             return $results;
         }
 
-        public static function print_results($results) {
-            TextSearch::print_results($results);
+        public static function print_results($results, $opts) {
+            TextSearch::print_results($results, $opts);
         }
     }
 ?>

--- a/engines/ahmia/hidden_service.php
+++ b/engines/ahmia/hidden_service.php
@@ -23,6 +23,7 @@
                     array (
                         "title" => $title ? htmlspecialchars($title) : "No description provided",
                         "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
                         "base_url" => htmlspecialchars(get_base_url($url)),
                         "description" => htmlspecialchars($description)
                     )

--- a/engines/bittorrent/merge.php
+++ b/engines/bittorrent/merge.php
@@ -34,7 +34,7 @@
             return $results; 
         }
 
-        public static function print_results($results) {
+        public static function print_results($results, $opts) {
             echo "<div class=\"text-result-container\">";
 
             if (empty($results)) {

--- a/engines/invidious/video.php
+++ b/engines/invidious/video.php
@@ -23,6 +23,7 @@
                         array (
                             "title" => htmlspecialchars($title),
                             "url" =>  htmlspecialchars($url),
+                            // base_url is to be removed in the future, see #47
                             "base_url" => htmlspecialchars(get_base_url($url)),
                             "uploader" => htmlspecialchars($uploader),
                             "views" => htmlspecialchars($views),
@@ -43,7 +44,7 @@
                     $title = $result["title"];
                     $url = $result["url"];
                     $url = check_for_privacy_frontend($url, $opts);
-                    $base_url = $result["base_url"];
+                    $base_url = get_base_url($url);
                     $uploader = $result["uploader"];
                     $views = $result["views"];
                     $date = $result["date"];

--- a/engines/invidious/video.php
+++ b/engines/invidious/video.php
@@ -14,7 +14,6 @@
                 if ($response["type"] == "video") {
                     $title = $response["title"];
                     $url = "https://youtube.com/watch?v=" . $response["videoId"];
-                    $url = check_for_privacy_frontend($url, $this->opts);
                     $uploader = $response["author"];
                     $views = $response["viewCount"];
                     $date = $response["publishedText"];
@@ -37,12 +36,13 @@
             return $results;
         }
 
-        public static function print_results($results) {
+        public static function print_results($results, $opts) {
             echo "<div class=\"text-result-container\">";
 
                 foreach($results as $result) {
                     $title = $result["title"];
                     $url = $result["url"];
+                    $url = check_for_privacy_frontend($url, $opts);
                     $base_url = $result["base_url"];
                     $uploader = $result["uploader"];
                     $views = $result["views"];

--- a/engines/qwant/image.php
+++ b/engines/qwant/image.php
@@ -24,7 +24,6 @@
                         $encoded_url_split1 = explode("==/", $encoded_url)[1];
                         $encoded_url_split2 = explode("?position", $encoded_url_split1)[0];
                         $real_url = urldecode(base64_decode($encoded_url_split2));
-                        $real_url = check_for_privacy_frontend($real_url, $this->opts);
 
                         $alt = $image->getAttribute("alt");
                         $thumbnail = urlencode($image->getAttribute("src"));
@@ -43,7 +42,7 @@
             return $results;
         }
         
-        public static function print_results($results) {
+        public static function print_results($results, $opts) {
             echo "<div class=\"image-result-container\">";
 
                 foreach($results as $result)
@@ -51,6 +50,7 @@
                     $thumbnail = urlencode($result["thumbnail"]);
                     $alt = $result["alt"];
                     $url = $result["url"];
+                    $url = check_for_privacy_frontend($url, $opts);
 
                     echo "<a title=\"$alt\" href=\"$url\" target=\"_blank\">";
                     echo "<img src=\"image_proxy.php?url=$thumbnail\">";

--- a/engines/special/wikipedia.php
+++ b/engines/special/wikipedia.php
@@ -20,7 +20,7 @@
 
             $description = substr($first_page["extract"], 0, 250) . "...";
 
-            $source = check_for_privacy_frontend("https://$this->wikipedia_language.wikipedia.org/wiki/$this->query", $this->opts);
+            $source = "https://$this->wikipedia_language.wikipedia.org/wiki/$this->query";
             $response = array(
                 "special_response" => array(
                     "response" => htmlspecialchars($description),

--- a/engines/text/duckduckgo.php
+++ b/engines/text/duckduckgo.php
@@ -30,22 +30,18 @@
             if (!$xpath)
                 return $results;
             
-            foreach($xpath->query("/html/body/div[1]/div[". count($xpath->query('/html/body/div[1]/div')) ."]/div/div/div[contains(@class, 'web-result')]/div") as $result)
-            {
+            foreach($xpath->query("/html/body/div[1]/div[". count($xpath->query('/html/body/div[1]/div')) ."]/div/div/div[contains(@class, 'web-result')]/div") as $result) {
                 $url = $xpath->evaluate(".//h2[@class='result__title']//a/@href", $result)[0];
                 
                 if ($url == null)
                     continue;
 
-                if (!empty($results)) // filter duplicate results
-                {
+                if (!empty($results)) // filter duplicate results {
                     if (end($results)["url"] == $url->textContent)
                         continue;
                 }
 
                 $url = $url->textContent;
-
-                $url = check_for_privacy_frontend($url, $this->opts);
 
                 $title = $xpath->evaluate(".//h2[@class='result__title']", $result)[0];
                 $description = $xpath->evaluate(".//a[@class='result__snippet']", $result)[0];

--- a/engines/text/duckduckgo.php
+++ b/engines/text/duckduckgo.php
@@ -50,6 +50,7 @@
                     array (
                         "title" => htmlspecialchars($title->textContent),
                         "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
                         "base_url" => htmlspecialchars(get_base_url($url)),
                         "description" =>  $description == null ?
                                           "No description was provided for this site." :

--- a/engines/text/google.php
+++ b/engines/text/google.php
@@ -61,6 +61,7 @@
                     array (
                         "title" => htmlspecialchars($title->textContent),
                         "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
                         "base_url" => htmlspecialchars(get_base_url($url)),
                         "description" =>  $description == null ?
                                           "No description was provided for this site." :

--- a/engines/text/google.php
+++ b/engines/text/google.php
@@ -53,7 +53,6 @@
                 }
 
                 $url = $url->textContent;
-                $url = check_for_privacy_frontend($url, $this->opts);
 
                 $title = $xpath->evaluate(".//h3", $result)[0];
                 $description = $xpath->evaluate(".//div[contains(@class, 'VwiC3b')]", $result)[0];

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -104,7 +104,7 @@
                 $url = $result["url"];
                 $url = check_for_privacy_frontend($url, $opts);
 
-                $base_url = $result["base_url"];
+                $base_url = get_base_url($url);
                 $description = $result["description"];
 
                 echo "<div class=\"text-result-wrapper\">";

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -55,7 +55,7 @@
             return $results;
         }
 
-        public static function print_results($results) {
+        public static function print_results($results, $opts)  {
 
             if (empty($results)) {
                 echo "<div class=\"text-result-container\"><p>An error occured fetching results</p></div>";
@@ -69,8 +69,7 @@
 
             $special = $results[0];
 
-            if (array_key_exists("did_you_mean", $special)) 
-            {
+            if (array_key_exists("did_you_mean", $special)) {
                 $didyoumean = $special["did_you_mean"];
                 $new_url = "/search.php?q="  . urlencode($didyoumean);
                 echo "<p class=\"did-you-mean\">Did you mean ";
@@ -78,32 +77,33 @@
                 echo "?</p>";
             }
 
-            if (array_key_exists("special_response", $special)) 
-            {
+            if (array_key_exists("special_response", $special)) {
                 $response = $special["special_response"]["response"];
                 $source = $special["special_response"]["source"];
 
                 echo "<p class=\"special-result-container\">";
-                if (array_key_exists("image", $special["special_response"]))
-                {
+                if (array_key_exists("image", $special["special_response"])) {
                     $image_url = $special["special_response"]["image"];
                     echo "<img src=\"image_proxy.php?url=$image_url\">";
                 }
                 echo $response;
-                if ($source)
+                if ($source) {
+                    $source = check_for_privacy_frontend($source, $opts);
                     echo "<a href=\"$source\" target=\"_blank\">$source</a>";
+                }
                 echo "</p>";
             }
 
             echo "<div class=\"text-result-container\">";
 
-            foreach($results as $result)
-            {
+            foreach($results as $result) {
                 if (!array_key_exists("title", $result))
                     continue;
 
                 $title = $result["title"];
                 $url = $result["url"];
+                $url = check_for_privacy_frontend($url, $opts);
+
                 $base_url = $result["base_url"];
                 $description = $result["description"];
 
@@ -120,8 +120,7 @@
         }
     }
 
-    function check_ddg_bang($query, $opts)
-    {
+    function check_ddg_bang($query, $opts) {
 
         $bangs_json = file_get_contents("static/misc/ddg_bang.json");
         $bangs = json_decode($bangs_json, true);
@@ -133,22 +132,18 @@
         
         $bang_url = null;
 
-        foreach($bangs as $bang)
-        {
-            if ($bang["t"] == $search_word)
-            {
+        foreach($bangs as $bang) {
+            if ($bang["t"] == $search_word) {
                 $bang_url = $bang["u"];
                 break;
             }
         }
 
-        if ($bang_url)
-        {
+        if ($bang_url) {
             $bang_query_array = explode("!" . $search_word, $query);
             $bang_query = trim(implode("", $bang_query_array));
 
             $request_url = str_replace("{{{s}}}", str_replace('%26quot%3B','%22', urlencode($bang_query)), $bang_url);
-            $request_url = check_for_privacy_frontend($request_url, $opts);
 
             header("Location: " . $request_url);
             die();

--- a/misc/search_engine.php
+++ b/misc/search_engine.php
@@ -54,7 +54,7 @@
             return $results;
         }
 
-        static public function print_results($results){}
+        public static function print_results($results, $opts) {}
     }
 
     function load_opts() {
@@ -165,7 +165,7 @@
             return $results;
 
         print_elapsed_time($start_time);
-        $search_category->print_results($results);
+        $search_category->print_results($results, $opts);
 
         return $results;
     }

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -1,8 +1,7 @@
 <?php
     function get_base_url($url) {
-        $split_url = explode("/", $url);
-        $base_url = $split_url[0] . "//" . $split_url[2] . "/";
-        return $base_url;
+        $parsed = parse_url($url);
+        return $parsed["scheme"] . "://" . $parsed["host"] . "/";
     }
 
     function get_root_domain($url) {


### PR DESCRIPTION
Moves checking for privacy frontend to printing results, this way when doing fallback the instance options from the user's instance are always used. 

Closes #47 
Moves `base_url` parsing to printing results, however leaving `base_url` in results array for backwards compatibility. This can and should be removed once all instances have upgraded to this patch.