### PR TITLE
Fix adding as search provider in Firefox

### DIFF
--- a/misc/header.php
+++ b/misc/header.php
@@ -6,7 +6,7 @@
         <meta name="description" content="A privacy respecting meta search engine."/>
         <meta name="referrer" content="no-referrer"/>
         <link rel="stylesheet" type="text/css" href="static/css/styles.css"/>
-        <link title="LibreY search" type="application/opensearchdescription+xml" href="opensearch.xml?method=POST" rel="search"/>
+        <link title="LibreY search" type="application/opensearchdescription+xml" href="opensearch.xml" rel="search"/>
         <link rel="stylesheet" type="text/css" href="<?php
 $theme = $_REQUEST["theme"] ?? trim(htmlspecialchars($_COOKIE["theme"] ?? "dark"));
                 echo "static/css/" . $theme . ".css";


### PR DESCRIPTION
Remove `?method=POST` to allow Firefox to correctly add Librey as an opensearch provider

Resolves #61 