### PR TITLE
Add localization for english text on LibreY

### DIFF
--- a/donate.php
+++ b/donate.php
@@ -10,8 +10,7 @@
     <div class="donate-container">
       <!-- librex dev -->
       <h2>
-        Donate to the original developer of Libre<span class="Y">X</span>, a
-        project LibreY tries to improve.
+<?php printftext("donate_original_developer", "Libre<span class=\"Y\">X</span>")?>
       </h2>
 
       <div class="flexbox-column">
@@ -46,11 +45,9 @@
         <hr class="small-line" />
 
         <!-- librey dev -->
-        <h2>
-          Donate to the person that forked LibreX into Libre<span class="Y"
-            >Y</span
-          >
-        </h2>
+      <h2>
+<?php printftext("donate_fork", "Libre<span class=\"Y\">X</span>")?>
+      </h2>
 
         <div class="qr-box">
           <div class="inner-wrap">

--- a/engines/ahmia/hidden_service.php
+++ b/engines/ahmia/hidden_service.php
@@ -21,7 +21,7 @@
 
                 array_push($results,
                     array (
-                        "title" => $title ? htmlspecialchars($title) : "No description provided",
+                        "title" => $title ? htmlspecialchars($title) : TEXTS["result_no_description"],
                         "url" =>  htmlspecialchars($url),
                         // base_url is to be removed in the future, see #47
                         "base_url" => htmlspecialchars(get_base_url($url)),

--- a/engines/bittorrent/merge.php
+++ b/engines/bittorrent/merge.php
@@ -38,7 +38,7 @@
             echo "<div class=\"text-result-container\">";
 
             if (empty($results)) {
-                echo "<p>There are no results. Please try different keywords!</p>";
+                echo "<p>" . TEXTS["failure_empty"] . "</p>";
                 return;
             }
 

--- a/engines/librex/fallback.php
+++ b/engines/librex/fallback.php
@@ -67,7 +67,7 @@
 
         return array(
             "error" => array(
-                "message" => "No results found. Unable to fallback to other instances."
+                "message" => TEXTS["failure_fallback"]
             )
         );
     }

--- a/engines/text/duckduckgo.php
+++ b/engines/text/duckduckgo.php
@@ -1,7 +1,6 @@
 <?php
     class DuckDuckGoRequest extends EngineRequest {
-        function get_request_url()
-        {
+        public function get_request_url() {
             $query_encoded = str_replace("%22", "\"", urlencode($this->query));
             $results = array();
 
@@ -53,7 +52,7 @@
                         // base_url is to be removed in the future, see #47
                         "base_url" => htmlspecialchars(get_base_url($url)),
                         "description" =>  $description == null ?
-                                          "No description was provided for this site." :
+                                          TEXTS["result_no_description"] :
                                           htmlspecialchars($description->textContent)
                     )
                 );

--- a/engines/text/google.php
+++ b/engines/text/google.php
@@ -64,7 +64,7 @@
                         // base_url is to be removed in the future, see #47
                         "base_url" => htmlspecialchars(get_base_url($url)),
                         "description" =>  $description == null ?
-                                          "No description was provided for this site." :
+                                          TEXTS["result_no_description"] :
                                           htmlspecialchars($description->textContent)
                     )
                 );
@@ -72,7 +72,7 @@
 
             if (empty($results) && !str_contains($response, "Our systems have detected unusual traffic from your computer network.")) {
                 $results["error"] = array(
-                    "message" => "There are no results. Please try different keywords!"
+                    "message" => TEXTS["failure_empty"]
                 );
             }
 

--- a/index.php
+++ b/index.php
@@ -10,8 +10,8 @@
                 <input type="hidden" name="t" value="0"/>
                 <input type="submit" class="hide"/>
                 <div class="search-button-wrapper">
-                    <button name="t" value="0" type="submit">Search with LibreY</button>
-                    <button name="t" value="3" type="submit">Search torrents with LibreY</button>
+                <button name="t" value="0" type="submit"><?php printtext("search_button"); ?></button>
+                    <button name="t" value="3" type="submit"><?php printtext("torrent_search_button"); ?></button>
                 </div>
         </form>
 

--- a/instances.php
+++ b/instances.php
@@ -51,7 +51,7 @@
                 list_instances($librey_instances);
             ?>
 
-            <p>The following instances are running the older <a href="https://github.com/hnhx/librex">LibreX</a>:</p>
+                <p><?php printtext("instances_librex", "<a href=\"https://github.com/hnhx/librex\">LibreX</a>")?>:</p>
             <?php
                 list_instances($librex_instances);
             ?>

--- a/locale/en.php
+++ b/locale/en.php
@@ -1,0 +1,53 @@
+<?php
+
+return array(
+    "page_title" => "LibreY search",
+    "search_button" => "Search with LibreY",
+    "torrent_search_button" => "Search torrents with LibreY",
+
+    "source_code_link" => "Source",
+    "instances_link" => "Instances",
+    "settings_link" => "Settings",
+    "api_link" => "API",
+    "donate_link" => "Donate ❤️",
+
+    "latest_commit" => "Latest commit: %s",
+
+    "category_general" => "General",
+    "category_images" => "Images",
+    "category_videos" => "Videos",
+    "category_torrents" => "Torrents",
+    "category_tor" => "Tor",
+
+    "feature_disabled" => "The host has disabled this feature :C",
+
+    "settings_title" => "Settings",
+    "settings_theme" => "Theme",
+    "settings_special_disabled" => "Disable special queries (e.g.: currency conversion)",
+
+    "settings_frontends" => "Privacy friendly frontends",
+    "settings_frontends_description" => "For an example if you want to view YouTube without getting spied on, click on \"Invidious\", find the instance that is most suitable for you then paste it in (correct format: https://example.com)",
+    "settings_frontends_disable" => "Disable frontends",
+
+    "settings_search_settings" => "Search settings",
+    "settings_language" => "Language",
+
+    "settings_number_of_results" => "Number of results per page",
+
+    "settings_safe_search" => "Safe search",
+    "settings_save" => "Save",
+    "settings_reset" => "Reset",
+
+
+    "failure_fallback" => "No results found. Unable to fallback to other instances.",
+    "failure_empty" => "No results found. Please try different keywords!",
+    "result_no_description" => "No description was provided for this site.",
+
+    "instances_librex" => "The following instances are running the older %s",
+
+    "donate_original_developer" => "Donate to the original developer of %s, a
+        project LibreY tries to improve.",
+    "donate_fork" => "Donate to the person that forked LibreX into %s"
+);
+
+?>

--- a/locale/localization.php
+++ b/locale/localization.php
@@ -1,0 +1,27 @@
+<?php
+
+function printtext($key) {
+    echo TEXTS[$key];
+}
+
+function printftext() {
+    $argv = func_get_args();
+    $key = array_shift($argv);
+    vprintf(TEXTS[$key], $argv);
+}
+
+// default to language "en"
+$locale = "en";
+
+$accept_language_header = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+
+if ($accept_language_header) {
+    foreach(explode(",", explode(";", $accept_language_header)[0]) as $header_language) {
+        if (file_exists("locale/$header_language.php")) {
+            $locale = $header_language;
+        }
+    }
+}
+
+define("TEXTS", require "locale/$locale.php");
+?>

--- a/locale/localization.php
+++ b/locale/localization.php
@@ -19,6 +19,7 @@ if ($accept_language_header) {
     foreach(explode(",", explode(";", $accept_language_header)[0]) as $header_language) {
         if (file_exists("locale/$header_language.php")) {
             $locale = $header_language;
+            break;
         }
     }
 }

--- a/misc/footer.php
+++ b/misc/footer.php
@@ -1,15 +1,15 @@
 <div class="footer-container">
     <a href="./">LibreY</a>
-    <a href="https://github.com/Ahwxorg/librey/" target="_blank">Source</a>
-    <a href="./instances.php" target="_blank">Instances</a>
-    <a href="./settings.php">Settings</a>
-    <a href="./api.php" target="_blank">API</a>
-    <a href="./donate.php">Donate ❤️</a>
+    <a href="https://github.com/Ahwxorg/librey/" target="_blank"><?php printtext("source_code_link");?></a>
+    <a href="./instances.php" target="_blank"><?php printtext("instances_link");?></a>
+    <a href="./settings.php"><?php printtext("settings_link");?></a>
+    <a href="./api.php" target="_blank"><?php printtext("api_link");?></a>
+    <a href="./donate.php"><?php printtext("donate_link");?></a>
 </div>
 <div class="git-container">
     <?php
         $hash = file_get_contents(".git/refs/heads/main");
-        echo "<a href=\"https://github.com/Ahwxorg/librey/commit/$hash\" target=\"_blank\">Latest commit: $hash</a>";
+        echo "<a href=\"https://github.com/Ahwxorg/librey/commit/$hash\" target=\"_blank\">" . printftext("latest_commit", $hash) . "</a>";
     ?>
 </div>
 </body>

--- a/misc/header.php
+++ b/misc/header.php
@@ -1,3 +1,4 @@
+<?php require "locale/localization.php"; ?>
 <!DOCTYPE html >
 <html lang="en">
     <head>
@@ -6,7 +7,7 @@
         <meta name="description" content="A privacy respecting meta search engine."/>
         <meta name="referrer" content="no-referrer"/>
         <link rel="stylesheet" type="text/css" href="static/css/styles.css"/>
-        <link title="LibreY search" type="application/opensearchdescription+xml" href="opensearch.xml?method=POST" rel="search"/>
+        <link title="<?php printtext("page_title"); ?>" type="application/opensearchdescription+xml" href="opensearch.xml?method=POST" rel="search"/>
         <link rel="stylesheet" type="text/css" href="<?php
 $theme = $_REQUEST["theme"] ?? trim(htmlspecialchars($_COOKIE["theme"] ?? "dark"));
                 echo "static/css/" . $theme . ".css";

--- a/misc/search_engine.php
+++ b/misc/search_engine.php
@@ -120,7 +120,7 @@
 
             case 3:
                 if ($opts->disable_bittorent_search) {
-                    echo "<p class=\"text-result-container\">The host disabled this feature! :C</p>";
+                    echo "<p class=\"text-result-container\">" . TEXTS["feature_disabled"] . "</p>";
                     break;
                 }
 
@@ -129,7 +129,7 @@
 
             case 4:
                 if ($opts->disable_hidden_service_search) {
-                    echo "<p class=\"text-result-container\">The host disabled this feature! :C</p>";
+                    echo "<p class=\"text-result-container\">" . TEXTS["feature_disabled"] . "</p>";
                     break;
                 }
                 require "engines/ahmia/hidden_service.php";

--- a/search.php
+++ b/search.php
@@ -29,7 +29,7 @@
 <title>
 <?php
     echo $opts->query;
-?> - LibreY</title>
+    ?> - <?php printtext("page_title");?></title>
 </head>
     <body>
         <form class="sub-search-container" method="get" autocomplete="off">
@@ -65,7 +65,7 @@
                             continue;
                         }
 
-                        echo "<a " . (($category_index == $opts->type) ? "class=\"active\" " : "") . "href=\"./search.php?q=" . urlencode($opts->query) . "&p=0&t=" . $category_index . "\"><img src=\"static/images/" . $category . "_result.png\" alt=\"" . $category . " result\" />" . ucfirst($category)  . "</a>";
+                        echo "<a " . (($category_index == $opts->type) ? "class=\"active\" " : "") . "href=\"./search.php?q=" . urlencode($opts->query) . "&p=0&t=" . $category_index . "\"><img src=\"static/images/" . $category . "_result.png\" alt=\"" . $category . " result\" />" . TEXTS["category_$category"]  . "</a>";
                     }
                 ?>
             </div>

--- a/settings.php
+++ b/settings.php
@@ -33,14 +33,14 @@
         require "misc/header.php";
 ?>
 
-    <title>LibreY - Settings</title>
+    <title>LibreY - <?php printtext("settings_title");?></title>
     </head>
     <body>
         <div class="misc-container">
             <h1>Settings</h1>
             <form method="post" enctype="multipart/form-data" autocomplete="off">
               <div>
-                <label for="theme">Theme:</label>
+                <label for="theme"><?php printtext("settings_theme");?>:</label>
                 <select name="theme">
                 <?php
                     $themes = "<option value=\"dark\">Dark</option>
@@ -70,12 +70,12 @@
                 </select>
                 </div>
                 <div>
-                    <label>Disable special queries (e.g.: currency conversion)</label>
+                    <label><?php printtext("settings_special_disabled");?></label>
                     <input type="checkbox" name="disable_special" <?php echo $opts->disable_special ? "checked"  : ""; ?> >
                 </div>
 
-                <h2>Privacy friendly frontends</h2>
-                <p>For an example if you want to view YouTube without getting spied on, click on "Invidious", find the instance that is most suitable for you then paste it in (correct format: https://example.com)</p>
+                <h2><?php printtext("settings_frontends");?></h2>
+                <p><?php printtext("settings_frontends_description");?></p>
                 <div class="settings-textbox-container">
                       <?php
                            foreach($opts->frontends as $frontend => $data)
@@ -90,14 +90,14 @@
                       ?>
                 </div>
                 <div>
-                    <label>Disable frontends</label>
+                    <label><?php printtext("settings_frontends_disable");?></label>
                     <input type="checkbox" name="disable_frontends" <?php echo $opts->disable_frontends ? "checked"  : ""; ?> >
                 </div>
 
-                <h2>Search settings</h2>
+                <h2><?php printtext("settings_search_settings");?></h2>
                 <div class="settings-textbox-container">
                     <div>
-                        <span>Language</span>
+                        <span><?php printtext("settings_language");?></span>
                         <select name="language">
                         <?php
 
@@ -116,18 +116,18 @@
                         </select>
                     </div>
                     <div>
-                        <label>Number of results per page</label>
+                        <label><?php printtext("settings_number_of_results");?></label>
                         <input type="number" name="number_of_results" value="<?php echo htmlspecialchars($opts->number_of_results ?? "10") ?>" >
                     </div>
                 </div>
                 <div>
-                    <label>Safe search</label>
+                    <label><?php printtext("settings_safe_search");?></label>
                     <input type="checkbox" name="safe_search" <?php echo $opts->safe_search ? "checked"  : ""; ?> >
                 </div>
 
                 <div>
-                  <button type="submit" name="save" value="1">Save</button>
-                  <button type="submit" name="reset" value="1">Reset</button>
+                  <button type="submit" name="save" value="1"><?php printtext("settings_save");?></button>
+                  <button type="submit" name="reset" value="1"><?php printtext("settings_reset");?></button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
Closes #70

Rudamentary basis for localisation. Currently the only language that is implemented is English, going by the original texts in LibreY. Locales can be added easily in `locales/`, going by the language setting of the user's browser. Potentially may allow setting this through a configuration option in the future. 

Before merging, please check that no text was missed, no typos were made and no text appears incorrectly. 