### PR TITLE
fixed fetching magnet links from 1337x

### DIFF
--- a/engines/bittorrent/get_magnet_1337x.php
+++ b/engines/bittorrent/get_magnet_1337x.php
@@ -4,9 +4,9 @@
 
     $url = $_REQUEST["url"];
 
-    $response = request($url);
+    $response = request($url, $config->curl_settings);
     $xpath = get_xpath($response);
-
+    
     $magnet = $xpath->query("//main/div/div/div/div/div/ul/li/a/@href")[0]->textContent;
     $magnet_without_tracker = explode("&tr=", $magnet)[0];
     $magnet = $magnet_without_tracker . $config->bittorent_trackers;

--- a/image_proxy.php
+++ b/image_proxy.php
@@ -11,7 +11,7 @@
     if (in_array($requested_root_domain, $allowed_domains))
     {
       $image = $url;
-      $image_src = request($image);
+      $image_src = request($image, $config->curl_settings);
 
       header("Content-Type: image/png");
       echo $image_src;

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -77,11 +77,9 @@
         return $xpath;
     }
 
-    function request($url) {
-        $config ??= require "config.php";
-
+    function request($url, $conf) {
         $ch = curl_init($url);
-        curl_setopt_array($ch, $config->curl_settings);
+        curl_setopt_array($ch, $conf);
         $response = curl_exec($ch);
 
         return $response;


### PR DESCRIPTION
Fetching magnet links was not working due to a bug in the request() function in tools.php. I fixed the issue by passing in the curl_settings array as a parameter to the request() function from the callerss since all currently existing callers include the config.php file anyways.