### PR TITLE
QOL: Add define (keyword) to make a dictionary search

### DIFF
--- a/engines/special/definition.php
+++ b/engines/special/definition.php
@@ -7,7 +7,7 @@
             $word_to_define = $reversed_split_q[1];
             return "https://api.dictionaryapi.dev/api/v2/entries/en/$word_to_define";
         }
-        
+
         public function parse_results($response) {
             $json_response = json_decode($response, true);
 
@@ -23,7 +23,7 @@
                     )
                 );
             }
-        
+
         }
     }
 ?>

--- a/engines/special/definition.php
+++ b/engines/special/definition.php
@@ -4,7 +4,7 @@
         public function get_request_url() {
             $split_query = explode(" ", $this->query);
             $reversed_split_q = array_reverse($split_query);
-            $word_to_define = $reversed_split_q[1];
+            $word_to_define = $reversed_split_q[1] == "define" ? $reversed_split_q[0] : $reversed_split_q[1];
             return "https://api.dictionaryapi.dev/api/v2/entries/en/$word_to_define";
         }
 

--- a/engines/special/special.php
+++ b/engines/special/special.php
@@ -13,7 +13,7 @@
             if ($amount_to_convert != 0)
                 return 1;
          }
-         else if (strpos($query_lower, "mean") && count($split_query) >= 2) // definition
+         else if ((strpos($query_lower, "mean")  || strpos($query_lower, "define")) && count($split_query) >= 2) // definition
          {
              return 2;
          }

--- a/engines/special/special.php
+++ b/engines/special/special.php
@@ -13,7 +13,7 @@
             if ($amount_to_convert != 0)
                 return 1;
          }
-         else if ((strpos($query_lower, "mean")  || strpos($query_lower, "define")) && count($split_query) >= 2) // definition
+         else if ((strpos($query_lower, "mean")  || strpos($query_lower, "define") == 0) && count($split_query) >= 2) // definition
          {
              return 2;
          }


### PR DESCRIPTION
Often I find myself searching "define [word]" to get the dictionary definition of something, this PR adds it as an option to make these queries