### PR TITLE
fix: "forked LibreX into LibreX" on both English and Dutch locales.

### DIFF
--- a/locale/en.php
+++ b/locale/en.php
@@ -47,7 +47,7 @@ return array(
 
     "donate_original_developer" => "Donate to the original developer of %s, a
         project LibreY tries to improve.",
-    "donate_fork" => "Donate to the person that forked LibreX into %s"
+    "donate_fork" => "Donate to the person that forked %s into LibreY"
 );
 
 ?>

--- a/locale/nl.php
+++ b/locale/nl.php
@@ -46,7 +46,7 @@ return array(
     "instances_librex" => "De volgende instances draaien de oudere versie; %s",
 
     "donate_original_developer" => "Doneer aan de originele ontwikkelaar van %s, een project dat LibreY probeert te verbeteren.",
-    "donate_fork" => "Doneer aan de persoon die LibreX heeft geforkt naar %s"
+    "donate_fork" => "Doneer aan de persoon die %s heeft geforkt naar LibreY"
 );
 
 ?>


### PR DESCRIPTION
Inside of the locales, "%s" is replaced with "LibreX" resulting in this on the donation page:
![image](https://github.com/Ahwxorg/LibreY/assets/103201875/e5d19ba3-852f-4da9-8b5d-c32469309d47)

This pull request fixes that on both Dutch and English locales.