### PR TITLE
Add localization to api

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,6 +1,7 @@
 <?php
     require "misc/tools.php";
     require "misc/search_engine.php";
+    require "locale/localization.php";
 
     $opts = load_opts();
 


### PR DESCRIPTION
Fix error causing api to fail in some cases. When /api.php is called, localization is not loaded so line 70 on `fallback.php` causes an exception. 

Fixed by adding localisation to api requests