### PR TITLE
Add option to disable api

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,9 +1,14 @@
 <?php
-    require "misc/tools.php";
     require "misc/search_engine.php";
     require "locale/localization.php";
 
     $opts = load_opts();
+    if ($opts->disable_api) {
+        echo "<p>" . TEXTS["api_unavailable"] . "</p>";
+        die();
+    }
+
+    require "misc/tools.php";
 
     if (!$opts->query) {
         echo "<p>Example API request: <a href=\"./api.php?q=gentoo&p=2&t=0\">./api.php?q=gentoo&p=2&t=0</a></p>

--- a/config.php.example
+++ b/config.php.example
@@ -26,7 +26,7 @@
         // how long in minutes to store results for in the cache
         "cache_time" => 20,
 
-        // disable the api feature
+        // Disable requests to /api.php
         "disable_api" => false,
 
         /*

--- a/config.php.example
+++ b/config.php.example
@@ -26,6 +26,9 @@
         // how long in minutes to store results for in the cache
         "cache_time" => 20,
 
+        // disable the api feature
+        "disable_api" => false,
+
         /*
             Preset privacy friendly frontends for users, these can be overwritten by users in the settings
             e.g.: Preset the invidious instance URL: "instance_url" => "https://yewtu.be",

--- a/config.php.example
+++ b/config.php.example
@@ -26,7 +26,7 @@
         // how long in minutes to store results for in the cache
         "cache_time" => 20,
 
-        // Disable requests to /api.php
+        // Disable requests to /api.php - HIGHLY recommended to keep this at false, this is what allows LibreY to still show results when Google/DuckDuckGo blocks te requests.
         "disable_api" => false,
 
         /*

--- a/docker/README.md
+++ b/docker/README.md
@@ -65,6 +65,7 @@ services:
       - CONFIG_INSTANCE_FALLBACK=true
       - CONFIG_RATE_LIMIT_COOLDOWN=25
       - CONFIG_CACHE_TIME=20
+      - CONFIG_DISABLE_API=false
       - CONFIG_TEXT_SEARCH_ENGINE=google
       - CURLOPT_PROXY_ENABLED=false
       - CURLOPT_PROXY=192.0.2.53:8388
@@ -103,6 +104,7 @@ This docker image was developed with high configurability in mind, so here is th
 | CONFIG_INSTANCE_FALLBACK | true | boolean | Choose whether or not to use the API on the backend to request to another LibreX/Y instance in case of rate limiting. |
 | CONFIG_RATE_LIMIT_COOLDOWN | 25 | integer | Time in minutes to wait before sending requests to Google again after a rate limit. |
 | CONFIG_CACHE_TIME | 20 | integer | Time in minutes to store results for in the cache. |
+| CONFIG_DISABLE_API | false | boolean | Disable requests to /api.php |
 
 ### Frontends
 | Variables | Default | Examples | Description |

--- a/docker/attributes.sh
+++ b/docker/attributes.sh
@@ -29,6 +29,7 @@ export CONFIG_HIDDEN_SERVICE_SEARCH=${CONFIG_HIDDEN_SERVICE_SEARCH:-false}
 export CONFIG_INSTANCE_FALLBACK="${CONFIG_INSTANCE_FALLBACK:-true}"
 export CONFIG_RATE_LIMIT_COOLDOWN="${CONFIG_RATE_LIMIT_COOLDOWN:-25}"
 export CONFIG_CACHE_TIME="${CONFIG_CACHE_TIME:-20}"
+export CONFIG_DISABLE_API="${CONFIG_DISABLE_API:-false}"
 
 # Supported apps integration configuration. These empty spaces can be set up using free hosts as pointers
 # A particular example is using the "https://yewtu.be" or a self-hosted host to integrate the invidious app to librey

--- a/docker/config.php
+++ b/docker/config.php
@@ -11,6 +11,7 @@
         "instance_fallback" => ${CONFIG_INSTANCE_FALLBACK},
         "request_cooldown" => ${CONFIG_RATE_LIMIT_COOLDOWN},
         "cache_time" => ${CONFIG_CACHE_TIME},
+        "disable_api" => ${CONFIG_DISABLE_API},
 
         "frontends" => array(
             "invidious" => array(

--- a/locale/en.php
+++ b/locale/en.php
@@ -47,7 +47,9 @@ return array(
 
     "donate_original_developer" => "Donate to the original developer of %s, a
         project LibreY tries to improve.",
-    "donate_fork" => "Donate to the person that forked %s into LibreY"
+    "donate_fork" => "Donate to the person that forked %s into LibreY",
+
+    "api_unavailable" => "This LibreY API is unavailable at the moment"
 );
 
 ?>


### PR DESCRIPTION
Add feature mentioned in #78, a bit of a nuclear option against spam to `/api.php`, but should allow instances that constantly get ratelimited to not recieve as much spam