### PR TITLE
Show fallback source

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -29,6 +29,9 @@
         // Disable requests to /api.php - HIGHLY recommended to keep this at false, this is what allows LibreY to still show results when Google/DuckDuckGo blocks te requests.
         "disable_api" => false,
 
+        // whether to show where the result is from on the results page
+        "show_result_source" => true,
+
         /*
             Preset privacy friendly frontends for users, these can be overwritten by users in the settings
             e.g.: Preset the invidious instance URL: "instance_url" => "https://yewtu.be",

--- a/engines/librex/fallback.php
+++ b/engines/librex/fallback.php
@@ -60,8 +60,11 @@
 
             $results = $librex_request->get_results();
 
-            if (!empty($results))
+            if (!empty($results)) {
+                $results["fallback_source"] = parse_url($instance)["host"];
+                error_log($results["fallback_source"]);
                 return $results;
+            }
 
             // on fail then do this
             $timeout = ($opts->request_cooldown ?? "1") * 60;

--- a/misc/search_engine.php
+++ b/misc/search_engine.php
@@ -170,7 +170,7 @@
         if (!$do_print || empty($results))
             return $results;
 
-        print_elapsed_time($start_time, $results);
+        print_elapsed_time($start_time, $results, $opts);
         $search_category->print_results($results, $opts);
 
         return $results;

--- a/misc/search_engine.php
+++ b/misc/search_engine.php
@@ -167,10 +167,10 @@
             $results = get_librex_results($opts);
         }
 
-        if (!$do_print)
+        if (!$do_print || empty($results))
             return $results;
 
-        print_elapsed_time($start_time);
+        print_elapsed_time($start_time, $results);
         $search_category->print_results($results, $opts);
 
         return $results;

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -97,9 +97,15 @@
         return trim(preg_replace("/\s+/", ' ', $string));
      }
 
-    function print_elapsed_time($start_time) {
+    function print_elapsed_time($start_time, $results) {
+            $source = "";
+            if (array_key_exists("fallback_source", $results)) {
+                $source = " from " . $results["fallback_source"];
+                unset($results["fallback_source"]);
+            }
+
             $end_time = number_format(microtime(true) - $start_time, 2, '.', '');
-            echo "<p id=\"time\">Fetched the results in $end_time seconds</p>";
+            echo "<p id=\"time\">Fetched the results in $end_time seconds$source</p>";
         }
 
     function print_next_page_button($text, $page, $query, $type) {

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -97,9 +97,9 @@
         return trim(preg_replace("/\s+/", ' ', $string));
      }
 
-    function print_elapsed_time($start_time, $results) {
+    function print_elapsed_time($start_time, $results, $opts) {
             $source = "";
-            if (array_key_exists("fallback_source", $results)) {
+            if (($opts->show_result_source ?? true) && array_key_exists("fallback_source", $results)) {
                 $source = " from " . $results["fallback_source"];
                 unset($results["fallback_source"]);
             }


### PR DESCRIPTION
Sometimes when using an instance its useful to know which other instance was used for fallback, since this way you can eliminate instances that give bogus results or otherwise broken result pages. It also helps to make it clear why the fetching took so long, indicating that fallback has indeed occured. 

Only merge this branch if you think this is a useful feature. With this current implementation there is no way for an instance maintainer to disable this message from being displayed. Also not properly tested, there may be issues with getting api requests with this feature since it writes the fallback source to the array of results temporarily. 