### PR TITLE
Implement more sources for text results

### DIFF
--- a/engines/librex/fallback.php
+++ b/engines/librex/fallback.php
@@ -61,8 +61,8 @@
             $results = $librex_request->get_results();
 
             if (!empty($results)) {
-                $results["fallback_source"] = parse_url($instance)["host"];
-                error_log($results["fallback_source"]);
+                $results["results_source"] = parse_url($instance)["host"];
+                error_log($results["results_source"]);
                 return $results;
             }
 

--- a/engines/text/brave.php
+++ b/engines/text/brave.php
@@ -1,0 +1,22 @@
+<?php
+    class BraveSearchRequest extends EngineRequest {
+        public function get_request_url() {
+            // TODO build url for brave search
+
+            return $url;
+        }
+
+        public function parse_results($response) {
+            $results = array();
+            $xpath = get_xpath($response);
+
+            if (!$xpath)
+                return $results;
+
+            // TODO implement brave search scraper
+
+           return $results;
+        }
+
+    }
+?>

--- a/engines/text/brave.php
+++ b/engines/text/brave.php
@@ -7,7 +7,7 @@
             $number_of_results = $this->opts->number_of_results;
 
             // TODO find the right parameters for the url
-            $url = "https://search.brave.com/search?q=$query_encoded&nfpr=1&start=$this->page";
+            $url = "https://search.brave.com/search?q=$query_encoded&nfpr=1&spellcheck=0&start=$this->page";
 
             if (3 > strlen($results_language) && 0 < strlen($results_language)) {
                 $url .= "&lr=lang_$results_language";

--- a/engines/text/brave.php
+++ b/engines/text/brave.php
@@ -1,7 +1,23 @@
 <?php
     class BraveSearchRequest extends EngineRequest {
         public function get_request_url() {
-            // TODO build url for brave search
+            $query_encoded = str_replace("%22", "\"", urlencode($this->query));
+
+            $results_language = $this->opts->language;
+            $number_of_results = $this->opts->number_of_results;
+
+            $url = "https://search.brave.com/search?q=$query_encoded&nfpr=1&start=$this->page";
+
+            if (3 > strlen($results_language) && 0 < strlen($results_language)) {
+                $url .= "&lr=lang_$results_language";
+                $url .= "&hl=$results_language";
+            }
+
+            if (3 > strlen($number_of_results) && 0 < strlen($number_of_results))
+                $url .= "&num=$number_of_results";
+
+            if (isset($_COOKIE["safe_search"]))
+                $url .= "&safe=medium";
 
             return $url;
         }
@@ -13,8 +29,38 @@
             if (!$xpath)
                 return $results;
 
-            // TODO implement brave search scraper
+            foreach($xpath->query("//div[@id='results']//div[contains(@class, 'snippet')]") as $result) {
+                $url = $xpath->evaluate(".//a[contains(@class, 'h')]//@href", $result)[0];
 
+                if ($url == null)
+                    continue;
+
+                $url = $url->textContent;
+
+                if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
+                    continue;
+
+                $title = $xpath->evaluate(".//a[contains(@class, 'h')]//div[contains(@class, 'url')]", $result)[0];
+
+                if ($title == null)
+                    continue;
+                $title = $title->textContent;
+
+                $description = $xpath->evaluate(".//div[contains(@class, 'snippet-content')]//div[contains(@class, 'snippet-description')]", $result)[0]->textContent;
+
+                array_push($results,
+                    array (
+                        "title" => htmlspecialchars($title),
+                        "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
+                        "base_url" => htmlspecialchars(get_base_url($url)),
+                        "description" =>  $description == null ?
+                                          TEXTS["result_no_description"] :
+                                          htmlspecialchars($description)
+                    )
+                );
+
+            }
            return $results;
         }
 

--- a/engines/text/brave.php
+++ b/engines/text/brave.php
@@ -6,6 +6,7 @@
             $results_language = $this->opts->language;
             $number_of_results = $this->opts->number_of_results;
 
+            // TODO find the right parameters for the url
             $url = "https://search.brave.com/search?q=$query_encoded&nfpr=1&start=$this->page";
 
             if (3 > strlen($results_language) && 0 < strlen($results_language)) {

--- a/engines/text/ecosia.php
+++ b/engines/text/ecosia.php
@@ -10,7 +10,7 @@
             $url = "https://www.ecosia.org/search?method=index&q=$query_encoded&p=$this->page";
 
             if (!is_null($results_language))
-                $url .= "&lang$results_language";
+                $url .= "&lang=$results_language";
 
             return $url;
         }

--- a/engines/text/ecosia.php
+++ b/engines/text/ecosia.php
@@ -1,0 +1,22 @@
+<?php
+    class EcosiaSearchRequest extends EngineRequest {
+        public function get_request_url() {
+            // TODO build url for ecosia
+
+            return $url;
+        }
+
+        public function parse_results($response) {
+            $results = array();
+            $xpath = get_xpath($response);
+
+            if (!$xpath)
+                return $results;
+
+            // TODO implement ecosia scraper
+
+           return $results;
+        }
+
+    }
+?>

--- a/engines/text/ecosia.php
+++ b/engines/text/ecosia.php
@@ -1,7 +1,16 @@
 <?php
     class EcosiaSearchRequest extends EngineRequest {
         public function get_request_url() {
-            // TODO build url for ecosia
+            $query_encoded = str_replace("%22", "\"", urlencode($this->query));
+
+            $results_language = $this->opts->language;
+            $number_of_results = $this->opts->number_of_results;
+
+            // TODO figure out how to not autocorrect
+            $url = "https://www.ecosia.org/search?method=index&q=$query_encoded&p=$this->page";
+
+            if (!is_null($results_language))
+                $url .= "&lang$results_language";
 
             return $url;
         }
@@ -13,8 +22,40 @@
             if (!$xpath)
                 return $results;
 
-            // TODO implement ecosia scraper
 
+            foreach($xpath->query("//div[contains(@class, 'mainline__result-wrapper')]") as $result) {
+                $url = $xpath->evaluate(".//article//div[contains(@class, 'result__body')]//div[contains(@class, 'result__header')]//div[contains(@class, 'result__info')]//a[contains(@class, 'result__link')]//@href", $result)[0];
+
+                if ($url == null)
+                    continue;
+
+                $url = $url->textContent;
+
+                if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
+                    continue;
+
+                $title = $xpath->evaluate(".//article//div[contains(@class, 'result__body')]//div[contains(@class, 'result__header')]//div[contains(@class, 'result__title')]//a//h2", $result)[0];
+
+                if ($title == null)
+                    continue;
+
+                $title = $title->textContent;
+
+                $description = $xpath->evaluate(".//article//div[contains(@class, 'result__body')]//div[contains(@class, 'result__columns')]//div[contains(@class, 'result__columns-start')]//div//div//div/p", $result)[0]->textContent;
+
+                array_push($results,
+                    array (
+                        "title" => htmlspecialchars($title),
+                        "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
+                        "base_url" => htmlspecialchars(get_base_url($url)),
+                        "description" =>  $description == null ?
+                                          TEXTS["result_no_description"] :
+                                          htmlspecialchars($description)
+                    )
+                );
+
+            }
            return $results;
         }
 

--- a/engines/text/google.php
+++ b/engines/text/google.php
@@ -46,7 +46,7 @@
                 if ($url == null)
                     continue;
 
-                    if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
+                if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
                         continue;
 
                 $url = $url->textContent;

--- a/engines/text/mojeek.php
+++ b/engines/text/mojeek.php
@@ -1,7 +1,17 @@
 <?php
     class MojeekSearchRequest extends EngineRequest {
         public function get_request_url() {
-            // TODO build url for mojeek
+            $query_encoded = str_replace("%22", "\"", urlencode($this->query));
+
+            $results_language = $this->opts->language;
+            $number_of_results = $this->opts->number_of_results;
+
+            // TODO figure out how to not autocorrect
+            $url = "https://www.mojeek.com/search?q=$query_encoded&p=$this->page";
+
+            // TODO language setting
+            if (!is_null($results_language))
+                $url .= "&lang=$results_language";
 
             return $url;
         }
@@ -13,8 +23,40 @@
             if (!$xpath)
                 return $results;
 
-            // TODO implement mojeek scraper
 
+            foreach($xpath->query("//ul[contains(@class, 'results-standard')]//li") as $result) {
+                $url = $xpath->evaluate(".//h2//a[contains(@class, 'title')]//@href", $result)[0];
+
+                if ($url == null)
+                    continue;
+
+                $url = $url->textContent;
+
+                if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
+                    continue;
+
+                $title = $xpath->evaluate(".//h2//a[contains(@class, 'title')]", $result)[0];
+
+                if ($title == null)
+                    continue;
+
+                $title = $title->textContent;
+
+                $description = $xpath->evaluate(".//p[contains(@class, 's')]", $result)[0]->textContent;
+
+                array_push($results,
+                    array (
+                        "title" => htmlspecialchars($title),
+                        "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
+                        "base_url" => htmlspecialchars(get_base_url($url)),
+                        "description" =>  $description == null ?
+                                          TEXTS["result_no_description"] :
+                                          htmlspecialchars($description)
+                    )
+                );
+
+            }
            return $results;
         }
 

--- a/engines/text/mojeek.php
+++ b/engines/text/mojeek.php
@@ -1,0 +1,22 @@
+<?php
+    class MojeekSearchRequest extends EngineRequest {
+        public function get_request_url() {
+            // TODO build url for mojeek
+
+            return $url;
+        }
+
+        public function parse_results($response) {
+            $results = array();
+            $xpath = get_xpath($response);
+
+            if (!$xpath)
+                return $results;
+
+            // TODO implement mojeek scraper
+
+           return $results;
+        }
+
+    }
+?>

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -21,16 +21,21 @@
             if (has_cached_results($this->cache_key))
                 return;
 
-            // TODO smart balance between engines
-            if ($this->engine == "auto") {
+            if ($this->engine == "auto")
                 $this->engine = $this->select_engine();
-            }
+
+            // no engine was selected
+            if (is_null($this->engine))
+                return;
+
+            // this only happens if a specific engine was selected, not if auto is used
+            if (has_cooldown($engine, $this->opts->cooldowns))
+                return;
 
             $this->engine_request = $this->get_engine_request($this->engine, $opts, $mh);
 
-            if (is_null($this->engine_request)) {
+            if (is_null($this->engine_request))
                 return;
-            }
 
             require "engines/special/special.php";
             $this->special_request = get_special_search_request($opts, $mh);
@@ -63,6 +68,9 @@
                 require "engines/text/brave.php";
                 return new BraveSearchRequest($opts, $mh);
             }
+
+            // if an invalid engine is selected, don't give any results
+            return null;
         }
 
         public function parse_results($response) {

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -50,7 +50,7 @@
             if (!has_cooldown($engine, $this->opts->cooldowns))
                 return $engine;
 
-            return select_engine();
+            return $this->select_engine();
         }
 
         private function get_engine_request($engine, $opts, $mh) {

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -1,8 +1,12 @@
 <?php
+    function get_engines() {
+        return array("google", "duckduckgo", "brave", "yandex");
+    }
+
     class TextSearch extends EngineRequest {
         protected $engine, $engine_request, $special_request;
         public function __construct($opts, $mh) {
-            $this->engines = array("google", "duckduckgo", "brave", "yandex");
+            $this->engines = get_engines();
             shuffle($this->engines);
 
             $this->query = $opts->query;

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -1,6 +1,6 @@
 <?php
     function get_engines() {
-        return array("google", "duckduckgo", "brave", "yandex");
+        return array("google", "duckduckgo", "brave", "yandex", "ecosia");
     }
 
     class TextSearch extends EngineRequest {
@@ -76,6 +76,11 @@
             if ($engine == "yandex") {
                 require "engines/text/yandex.php";
                 return new YandexSearchRequest($opts, $mh);
+            }
+
+            if ($engine == "ecosia") {
+                require "engines/text/ecosia.php";
+                return new EcosiaSearchRequest($opts, $mh);
             }
 
             // if an invalid engine is selected, don't give any results

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -2,9 +2,9 @@
     class TextSearch extends EngineRequest {
         protected $engine, $engine_request, $special_request;
         public function __construct($opts, $mh) {
-            $this->engines = array("google", "duckduckgo", "brave");
+            $this->engines = array("google", "duckduckgo", "brave", "yandex");
             shuffle($this->engines);
-            
+
             $this->query = $opts->query;
             $this->cache_key = "text:" . $this->query;
 
@@ -29,7 +29,7 @@
                 return;
 
             // this only happens if a specific engine was selected, not if auto is used
-            if (has_cooldown($engine, $this->opts->cooldowns))
+            if (has_cooldown($this->engine, $this->opts->cooldowns))
                 return;
 
             $this->engine_request = $this->get_engine_request($this->engine, $opts, $mh);
@@ -67,6 +67,11 @@
             if ($engine == "brave") {
                 require "engines/text/brave.php";
                 return new BraveSearchRequest($opts, $mh);
+            }
+
+            if ($engine == "yandex") {
+                require "engines/text/yandex.php";
+                return new YandexSearchRequest($opts, $mh);
             }
 
             // if an invalid engine is selected, don't give any results

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -14,7 +14,6 @@
                 check_ddg_bang($this->query, $opts);
 
             if ($this->engine == "google") {
-                
                 require "engines/text/google.php";
                 $this->engine_request = new GoogleRequest($opts, $mh);
             }
@@ -22,6 +21,11 @@
             if ($this->engine == "duckduckgo") {
                 require "engines/text/duckduckgo.php";
                 $this->engine_request = new DuckDuckGoRequest($opts, $mh);
+            }
+
+            if ($this->engine == "brave") {
+                require "engines/text/brave.php";
+                $this->engine_request = new BraveSearchRequest($opts, $mh);
             }
 
             if (has_cooldown($this->engine, $this->opts->cooldowns) && !has_cached_results($this->engine_request->url)) {

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -148,6 +148,8 @@
             echo "<div class=\"text-result-container\">";
 
             foreach($results as $result) {
+                if (!is_array($result))
+                    continue;
                 if (!array_key_exists("title", $result))
                     continue;
 

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -13,6 +13,12 @@
             if (substr($this->query, 0, 1) == "!" || substr($last_word_query, 0, 1) == "!")
                 check_ddg_bang($this->query, $opts);
 
+            // TODO smart balance between engines
+            if ($this->engine == "auto") {
+                $engines = array("google", "duckduckgo", "brave");
+                $this->engine = $engines[array_rand($engines)];
+            }
+
             if ($this->engine == "google") {
                 require "engines/text/google.php";
                 $this->engine_request = new GoogleRequest($opts, $mh);

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -1,6 +1,6 @@
 <?php
     function get_engines() {
-        return array("google", "duckduckgo", "brave", "yandex", "ecosia");
+        return array("google", "duckduckgo", "brave", "yandex", "ecosia", "mojeek");
     }
 
     class TextSearch extends EngineRequest {
@@ -81,6 +81,11 @@
             if ($engine == "ecosia") {
                 require "engines/text/ecosia.php";
                 return new EcosiaSearchRequest($opts, $mh);
+            }
+
+            if ($engine == "mojeek") {
+                require "engines/text/mojeek.php";
+                return new MojeekSearchRequest($opts, $mh);
             }
 
             // if an invalid engine is selected, don't give any results

--- a/engines/text/yandex.php
+++ b/engines/text/yandex.php
@@ -1,0 +1,22 @@
+<?php
+    class YandexSearchRequest extends EngineRequest {
+        public function get_request_url() {
+            // TODO build url for yandex
+
+            return $url;
+        }
+
+        public function parse_results($response) {
+            $results = array();
+            $xpath = get_xpath($response);
+
+            if (!$xpath)
+                return $results;
+
+            // TODO implement yandex scraper
+
+           return $results;
+        }
+
+    }
+?>

--- a/engines/text/yandex.php
+++ b/engines/text/yandex.php
@@ -9,7 +9,7 @@
             $url = "https://yandex.com/search?text=$query_encoded&nfpr=1&p=$this->page&noreask=1";
 
             if (!is_null($results_language))
-                $url .= "&lang$results_language";
+                $url .= "&lang=$results_language";
 
             return $url;
         }

--- a/engines/text/yandex.php
+++ b/engines/text/yandex.php
@@ -22,11 +22,10 @@
                 return $results;
 
             $r = $xpath->query("//ul[@id='search-result']");
-            if (empty($r)) {
+            if (empty($r))
                 return array("error" => array(
                     "message" => TEXTS["failure_empty"]
                 ));
-            }
 
             foreach($xpath->query("//li[contains(@class, 'serp-item')]") as $result) {
                 $url = $xpath->evaluate(".//div//div//a[contains(@class, 'link')]//@href", $result)[0];

--- a/engines/text/yandex.php
+++ b/engines/text/yandex.php
@@ -1,7 +1,15 @@
 <?php
     class YandexSearchRequest extends EngineRequest {
         public function get_request_url() {
-            // TODO build url for yandex
+            $query_encoded = str_replace("%22", "\"", urlencode($this->query));
+
+            $results_language = $this->opts->language;
+            $number_of_results = $this->opts->number_of_results;
+
+            $url = "https://yandex.com/search?text=$query_encoded&nfpr=1&p=$this->page";
+
+            if (!is_null($results_language))
+                $url .= "&lang$results_language";
 
             return $url;
         }
@@ -13,9 +21,48 @@
             if (!$xpath)
                 return $results;
 
-            // TODO implement yandex scraper
+            $r = $xpath->query("//ul[@id='search-result']");
+            if (empty($r)) {
+                return array("error" => array(
+                    "message" => TEXTS["failure_empty"]
+                ));
+            }
 
-           return $results;
+            foreach($xpath->query("//li[contains(@class, 'serp-item')]") as $result) {
+                $url = $xpath->evaluate(".//div//div//a[contains(@class, 'link')]//@href", $result)[0];
+
+                if ($url == null)
+                    continue;
+
+                $url = $url->textContent;
+
+                if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
+                    continue;
+
+                $title = $xpath->evaluate(".//div//div//a[contains(@class, 'link')]//h2[contains(@class, 'OrganicTitle-LinkText')]//span", $result)[0];
+
+                if ($title == null)
+                    continue;
+
+                $title = $title->textContent;
+
+                $description = $xpath->evaluate(".//div[contains(@class, 'Organic-ContentWrapper')]//div[contains(@class, 'text-container')]//span", $result)[0]->textContent;
+
+                array_push($results,
+                    array (
+                        "title" => htmlspecialchars($title),
+                        "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
+                        "base_url" => htmlspecialchars(get_base_url($url)),
+                        "description" =>  $description == null ?
+                                          TEXTS["result_no_description"] :
+                                          htmlspecialchars($description)
+                    )
+                );
+
+            }
+
+            return $results;
         }
 
     }

--- a/engines/text/yandex.php
+++ b/engines/text/yandex.php
@@ -6,7 +6,7 @@
             $results_language = $this->opts->language;
             $number_of_results = $this->opts->number_of_results;
 
-            $url = "https://yandex.com/search?text=$query_encoded&nfpr=1&p=$this->page";
+            $url = "https://yandex.com/search?text=$query_encoded&nfpr=1&p=$this->page&noreask=1";
 
             if (!is_null($results_language))
                 $url .= "&lang$results_language";

--- a/locale/en.php
+++ b/locale/en.php
@@ -32,6 +32,7 @@ return array(
 
     "settings_search_settings" => "Search settings",
     "settings_language" => "Language",
+    "settings_preferred_engine" => "Preferred Engine",
 
     "settings_number_of_results" => "Number of results per page",
 

--- a/misc/search_engine.php
+++ b/misc/search_engine.php
@@ -92,6 +92,8 @@
 
         $opts->curl_settings[CURLOPT_FOLLOWLOCATION] ??= true;
 
+        $opts->engine = $_REQUEST["engine"] ?? $_COOKIE["engine"] ?? $opts->preferred_engines["text"] ?? "auto";
+
         return $opts;
     }
 

--- a/misc/search_engine.php
+++ b/misc/search_engine.php
@@ -107,6 +107,7 @@
         $params .= "&safe=" . ($opts->safe_search ? 1 : 0);
         $params .= "&nf=" . ($opts->disable_frontends ? 1 : 0);
         $params .= "&ns=" . ($opts->disable_special ? 1 : 0);
+        $params .= "&engine=" . ($opts->engine ?? "auto");
 
         return $params;
     }

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -99,9 +99,9 @@
 
     function print_elapsed_time($start_time, $results, $opts) {
             $source = "";
-            if (($opts->show_result_source ?? true) && array_key_exists("fallback_source", $results)) {
-                $source = " from " . $results["fallback_source"];
-                unset($results["fallback_source"]);
+            if (array_key_exists("results_source", $results)) {
+                $source = " from " . $results["results_source"];
+                unset($results["results_source"]);
             }
 
             $end_time = number_format(microtime(true) - $start_time, 2, '.', '');

--- a/settings.php
+++ b/settings.php
@@ -97,6 +97,32 @@
                 <h2><?php printtext("settings_search_settings");?></h2>
                 <div class="settings-textbox-container">
                     <div>
+                        <span><?php printtext("settings_preferred_engine");?></span>
+                        <select name="engine">
+                        <?php
+                           require "engines/text/text.php";
+
+                           $engines = get_engines();
+
+                           $options = "";
+
+                           $options .= "<option value=\"\" " . (!isset($opts->engine) ? "selected" : "") . ">auto</option>";
+
+                           foreach ($engines as $engine) {
+                               $selected = $opts->engine == $engine ? "selected" : "";
+                               $options .= "<option value=\"$engine\" $selected>$engine</option>";
+                           }
+                           echo $options;
+                        ?>
+                        </select>
+                    </div>
+                    <div>
+                        <label><?php printtext("settings_number_of_results");?></label>
+                        <input type="number" name="number_of_results" value="<?php echo htmlspecialchars($opts->number_of_results ?? "10") ?>" >
+                    </div>
+                </div>
+                <div class="settings-textbox-container">
+                    <div>
                         <span><?php printtext("settings_language");?></span>
                         <select name="language">
                         <?php


### PR DESCRIPTION
This PR should aim to futher solve issues of being ratelimited by search result providers (ie Google) by scraping results from more sources on LibreY. Might possibly resolve #95

The following should be implemented:
- [x] allowing the user to select which search engine they want to recieve results from, or "auto" by default
- [x] switching search engines based on ratelimites or cooldowns when on auto, to balance requests
- [x] implement scrapers for the following engines:
  + [x] [search.brave.com](https://search.brave.com/)
  + [x] [ecosia.org](https://www.ecosia.org/)
  + [x] [yandex.com](https://yandex.com/)
  + [x] [mojeek.com](https://www.mojeek.com/)
 - [x] set prefered search engine when doing instance fallback
 
 
 I may need help implementing these scrapers, so if you would like to help contribute, please tell me which scraper you'd like to implement. Template files have been added for the mentioned engines, so that they can easily be integrated into LibreY.
