### PR TITLE
Fixed a Typo / undefined property 

### DIFF
--- a/engines/bittorrent/get_magnet_1337x.php
+++ b/engines/bittorrent/get_magnet_1337x.php
@@ -9,7 +9,7 @@
     
     $magnet = $xpath->query("//main/div/div/div/div/div/ul/li/a/@href")[0]->textContent;
     $magnet_without_tracker = explode("&tr=", $magnet)[0];
-    $magnet = $magnet_without_tracker . $config->bittorent_trackers;
+    $magnet = $magnet_without_tracker . $config->bittorrent_trackers;
 
     header("Location: $magnet")
 ?>

--- a/engines/bittorrent/nyaa.php
+++ b/engines/bittorrent/nyaa.php
@@ -26,7 +26,7 @@
                 if ($magnet_node->length > 0) {
                     $magnet = $magnet_node[0]->textContent;
                     $magnet_without_tracker = explode("&tr=", $magnet)[0];
-                    $magnet = $magnet_without_tracker . $this->opts->bittorent_trackers;
+                    $magnet = $magnet_without_tracker . $this->opts->bittorrent_trackers;
                 } else {
                     $magnet = "";
                 }

--- a/search.php
+++ b/search.php
@@ -59,7 +59,7 @@
                     {
                         $category_index = array_search($category, $categories);
 
-                        if (($opts->disable_bittorent_search && $category_index == 3) ||
+                        if (($opts->disable_bittorrent_search && $category_index == 3) ||
                             ($opts->disable_hidden_service_search && $category_index ==4))
                         {
                             continue;


### PR DESCRIPTION
[search.php](https://github.com/Ahwxorg/LibreY/commit/c1fd543ead1cbb5be44f062f8d6e1e87461c5ecd#diff-fe25e8545f067eb50fae0028b5dcdc76e168a985bd8806edcae066ae1f6a4f8b)
The issue was
`Undefined property: stdClass::$disable_bittorent_search in LibreY/search.php`

Fix:

`if (($opts->disable_bittorent_search && $category_index == 3) ||`

Turn that into

`if (($opts->disable_bittorrent_search && $category_index == 3) ||`

[engines/bittorrent/get_magnet_1337x.php](https://github.com/dehlirious/LibreY/commit/d5437f00a46b95abd8651449ccfc10b9589fb93f#diff-82a5090220f2e305c4db669929ee2b13c626c8826757e0cd4bc6f3d544f8fa68)
`$magnet = $magnet_without_tracker . $config->bittorent_trackers;`
into
`$magnet = $magnet_without_tracker . $config->bittorrent_trackers;`


And on [engines/bittorrent/nyaa.php](https://github.com/dehlirious/LibreY/commit/b703a4bdad6ababed213c43a26a0997012f3fd18#diff-838d061c6ffe6655829ce812faa108c00636918296bad9d01693761b6b767b70),

`PHP Warning:  Undefined property: stdClass::$bittorent_trackers`


Turn `$magnet = $magnet_without_tracker . $this->opts->bittorent_trackers;`
into
`$magnet = $magnet_without_tracker . $this->opts->bittorrent_trackers;`


And all is well.