### PR TITLE
Minor fixes

### DIFF
--- a/donate.php
+++ b/donate.php
@@ -21,7 +21,7 @@
           </div>
 
           <img
-            src="/static/images/btc.png"
+            src="static/images/btc.png"
             height="160"
             width="160"
             alt="btc qr code"
@@ -35,7 +35,7 @@
             </p>
           </div>
           <img
-            src="/static/images/xmr.png"
+            src="static/images/xmr.png"
             height="160"
             width="160"
             alt="xmr qr code (hnhx)"
@@ -57,7 +57,7 @@
               </p>
           </div>
           <img
-            src="/static/images/xmr-ahwx.png"
+            src="static/images/xmr-ahwx.png"
             height="160"
             width="160"
             alt="xmr qr code (ahwx)"
@@ -67,7 +67,7 @@
         <div class="flex-row">
           <a href="https://ko-fi.com/Ahwxorg" target="_blank"
             ><img
-              src="/static/images/kofi.png"
+              src="static/images/kofi.png"
               alt="kifi img"
               height="50"
               width="auto"
@@ -75,7 +75,7 @@
 
           <a href="https://www.buymeacoffee.com/ahwx" target="_blank">
             <img
-              src="/static/images/buy-me-a-coffee.png"
+              src="static/images/buy-me-a-coffee.png"
               height="50"
               width="auto"
               alt="buy-me-a-coffee img"
@@ -86,4 +86,4 @@
 
         
 
-<?php require "misc/footer.php"; ?>
+<?php require_once "misc/footer.php"; ?>

--- a/donate.php
+++ b/donate.php
@@ -86,4 +86,4 @@
 
         
 
-<?php require_once "misc/footer.php"; ?>
+<?php require "misc/footer.php"; ?>

--- a/engines/invidious/video.php
+++ b/engines/invidious/video.php
@@ -9,7 +9,7 @@
 
         public function parse_results($response) {
             $results = array();
-            $json_response = json_decode($response, true);
+            $json_response = json_decode($response, true) ?? [];
 
             foreach ($json_response as $response) {
                 if ($response["type"] == "video") {
@@ -41,26 +41,27 @@
         public static function print_results($results, $opts) {
             echo "<div class=\"text-result-container\">";
 
-                foreach($results as $result) {
-                    $title = $result["title"];
-                    $url = $result["url"];
-                    $url = check_for_privacy_frontend($url, $opts);
-                    $base_url = get_base_url($url);
-                    $uploader = $result["uploader"];
-                    $views = $result["views"];
-                    $date = $result["date"];
-                    $thumbnail = $result["thumbnail"];
+            foreach ($results as $result) {
+                $title = $result["title"] ?? '';
+                $url = $result["url"] ?? '';
+                $url = check_for_privacy_frontend($url, $opts);
+                $base_url = get_base_url($url);
+                $uploader = $result["uploader"] ?? '';
+                $views = $result["views"] ?? '';
+                $date = $result["date"] ?? '';
+                $thumbnail = $result["thumbnail"] ?? '';
 
-                    echo "<div class=\"text-result-wrapper\">";
-                    echo "<a href=\"$url\">";
-                    echo "$base_url";
-                    echo "<h2>$title</h2>";
-                    echo "<img class=\"video-img\" src=\"image_proxy.php?url=$thumbnail\">";
-                    echo "<br>";
-                    echo "<span>$uploader - $date - $views views</span>";
-                    echo "</a>";
-                    echo "</div>";
-                }
+                echo "<div class=\"text-result-wrapper\">";
+                echo "<a href=\"$url\">";
+                echo "$base_url";
+                echo "<h2>$title</h2>";
+                echo "<img class=\"video-img\" src=\"image_proxy.php?url=$thumbnail\">";
+                echo "<br>";
+                echo "<span>$uploader - $date - $views views</span>";
+                echo "</a>";
+                echo "</div>";
+            }
+
 
             echo "</div>";
         }

--- a/engines/librex/fallback.php
+++ b/engines/librex/fallback.php
@@ -53,7 +53,7 @@
             if (!(filter_var($instance, FILTER_VALIDATE_URL)))
                 continue;
 
-            if (parse_url($instance)["host"] == parse_url($_SERVER['HTTP_HOST'])["host"])
+            if (parse_url($instance)["host"] == $_SERVER['HTTP_HOST'])
                 continue;
 
             $librex_request = new LibreXFallback($instance, $opts, null);

--- a/engines/librex/fallback.php
+++ b/engines/librex/fallback.php
@@ -62,7 +62,6 @@
 
             if (!empty($results)) {
                 $results["results_source"] = parse_url($instance)["host"];
-                error_log($results["results_source"]);
                 return $results;
             }
 

--- a/engines/text/brave.php
+++ b/engines/text/brave.php
@@ -47,7 +47,7 @@
                     continue;
                 $title = $title->textContent;
 
-                $description = $xpath->evaluate(".//div[contains(@class, 'snippet-content')]//div[contains(@class, 'snippet-description')]", $result)[0]->textContent;
+                $description = ($xpath->evaluate(".//div[contains(@class, 'snippet-content')]//div[contains(@class, 'snippet-description')]", $result)[0] ?? null) ?->textContent ?? '';
 
                 array_push($results,
                     array (

--- a/engines/text/mojeek.php
+++ b/engines/text/mojeek.php
@@ -42,7 +42,7 @@
 
                 $title = $title->textContent;
 
-                $description = $xpath->evaluate(".//p[contains(@class, 's')]", $result)[0]->textContent;
+                $description = ($xpath->evaluate(".//p[contains(@class, 's')]", $result)[0] ?? null) ?->textContent ?? '';
 
                 array_push($results,
                     array (

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -102,7 +102,7 @@
             $results = $this->engine_request->get_results();
 
             if (empty($results)) {
-                set_cooldown($this->engine, ($opts->request_cooldown ?? "1") * 60, $this->opts->cooldowns);
+                set_cooldown($this->engine, ($this->opts->request_cooldown ?? "1") * 60, $this->opts->cooldowns);
             } else {
                 if ($this->special_request) {
                     $special_result = $this->special_request->get_results();

--- a/locale/localization.php
+++ b/locale/localization.php
@@ -7,7 +7,7 @@ function printtext($key) {
 function printftext() {
     $argv = func_get_args();
     $key = array_shift($argv);
-    vprintf(TEXTS[$key], $argv);
+    return vprintf(TEXTS[$key], $argv);
 }
 
 // default to language "en"

--- a/misc/search_engine.php
+++ b/misc/search_engine.php
@@ -4,7 +4,7 @@
         protected $url, $query, $page, $opts, $mh, $ch;
 
         protected $DO_CACHING = true;
-        function __construct($opts, $mh) {
+        public function __construct($opts, $mh) {
             $this->query = $opts->query;
             $this->page = $opts->page;
             $this->mh = $mh;

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -1,8 +1,15 @@
 <?php
     function get_base_url($url) {
         $parsed = parse_url($url);
-        return $parsed["scheme"] . "://" . $parsed["host"] . "/";
+
+        if (isset($parsed["scheme"]) && isset($parsed["host"]) && !empty($parsed["scheme"]) && !empty($parsed["host"])) {
+            return $parsed["scheme"] . "://" . $parsed["host"] . "/";
+        } else {
+			logStackTrace();
+            return "";
+        }
     }
+
 
     function get_root_domain($url) {
         return parse_url($url, PHP_URL_HOST);
@@ -135,6 +142,36 @@
         }
 
         return join($emoji);
+    }
+
+    function logStackTrace() {
+        // Get the stack trace
+        $stackTrace = debug_backtrace();
+
+        // Format the stack trace for logging
+        $logMessage = "Stack Trace: ";
+        foreach ($stackTrace as $index => $trace) {
+            // Skip the first entry as it's the current function call
+            if ($index === 0) {
+                continue;
+            }
+
+            // Build the log message for each stack frame
+            $logMessage .= "#{$index} ";
+            if (isset($trace['file'])) {
+                $logMessage .= "File: {$trace['file']} ";
+            }
+            if (isset($trace['line'])) {
+                $logMessage .= "Line: {$trace['line']} ";
+            }
+            if (isset($trace['function'])) {
+                $logMessage .= "Function: {$trace['function']} ";
+            }
+            $logMessage .= "\n";
+        }
+
+        // Log the stack trace to the error log
+        error_log($logMessage);
     }
 
 ?>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -94,7 +94,6 @@ a:hover,
 }
 
 .sub-search-container input {
-    margin-bottom: 20px;
     width: 580px;
     position: relative;
     left: 140px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -461,7 +461,6 @@ hr.small-line {
         padding: 10px;
         font-size: 28px;
         display: block;
-        margin-top: 0px;
         top: 0px;
         left: 0px;
     }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -550,7 +550,6 @@ hr.small-line {
     word-wrap: break-word;
     align-items: center;
     justify-content: space-between;
-    word-wrap: break-word;
     height: auto;
   }
 


### PR DESCRIPTION
[engines/text/text.php](https://github.com/Ahwxorg/LibreY/compare/main...dehlirious:LibreY:minor-changes#diff-3135b33aa1ac1282c3740031d7ce889713ebbac0154d37e7d54d8086ee3b93cf)
`set_cooldown($this->engine, ($opts->request_cooldown ?? "1") * 60, $this->opts->cooldowns);`
Using uninitalized $opts one second, then the proper $this->opts the second.

Changed that to 
`set_cooldown($this->engine, ($this->opts->request_cooldown ?? "1") * 60, $this->opts->cooldowns);`

<hr/>

[locale/localization.php](https://github.com/Ahwxorg/LibreY/compare/main...dehlirious:LibreY:minor-changes#diff-205a20f7bd4cac969a7115fe650c5c97447c75385743132d24a83487787e7abc)
function printftext() had no return!
Changed the functions end line to `return vprintf(TEXTS[$key], $argv);`

The difference is: 
Before, on index.php:
`<a href='XXCommitURL' target='_blank'></a>`

After:
`<a href='XXCommitURL' target='_blank'>56</a>`

<hr/>

In [misc/search_engine.php](https://github.com/Ahwxorg/LibreY/compare/main...dehlirious:LibreY:minor-changes#diff-09389626ef9da4931b2b12802b8a5d94379e5245e063ee383bd73122c8180067),
Declared visibility of __construct. Every other function had a declared visibility, why not? No harm, no foul. Plus, proper coding practice.

<hr/>

Then finally, I just removed three redundant lines of css in styles.css

`.sub-search-container input {`
`margin-bottom: 20px;` when `margin: 18px` was defined after it in the same class, rendered the original margin-bottom useless. Margin itself works, or go for the approach of defining margin then margin-bottom, but the 2px difference in my case was insignificant and worth removing the line entirely.

`.logomobile {`
`margin-top: 0px;` was defined twice

`.qr-box {`
`word-wrap: break-word;` was defined twice

<hr/>

[engines/text/brave.php](https://github.com/dehlirious/LibreY/commit/fe2a723645f270b0b27b73c68297c07ed09491f5#diff-a0d045014922e6104ccaf7786f115e73739a76e60e756f77e504553d78fc8929)
`PHP Warning:  Attempt to read property "textContent" on null`

`$description = $xpath->evaluate(".//div[contains(@class, 'snippet-content')]//div[contains(@class, 'snippet-description')]", $result)[0]->textContent;`
Into
`$description = ($xpath->evaluate(".//div[contains(@class, 'snippet-content')]//div[contains(@class, 'snippet-description')]", $result)[0] ?? null) ?->textContent ?? '';`

<hr/>

[engines/text/mojeek.php](https://github.com/dehlirious/LibreY/commit/c9433ee4b95e7cd837848b341fed2da716f34245#diff-a0ae572c510c4d655b956a704ee0d18a532463f769d671ff6cb8abe9ec95af96)
`PHP Warning:  Attempt to read property "textContent" on null`

`$description = $xpath->evaluate(".//p[contains(@class, 's')]", $result)[0]->textContent;`
into
`$description = ($xpath->evaluate(".//p[contains(@class, 's')]", $result)[0] ?? null) ?->textContent ?? '';`

<hr/>

[donate.php](https://github.com/dehlirious/LibreY/commit/2d3c98c93fddcd640a4e8dfba2aa043ef97910c1#diff-f03f10609338ef947443c6726ee45cc96aa8f30766df302e15bdf3b276cd4f9d)
Changed src="/static/example.png" into src="static/example.png" , when LibreY is in a subdirectory, these images were not loading. 

<hr/>

Also another problem on [engines/librex/fallback.php](https://github.com/dehlirious/LibreY/commit/ee22d85b1760119b5e5af8813e8c8cc594c74f9d#diff-3faf5ab79dd1b4ed9dae4fd4874312875abcbe9fea74d6ada6fa2e159f742748).
`$_SERVER['HTTP_HOST']` does not return `https://example.org` but `example.org`,
so using `parse_url($_SERVER['HTTP_HOST'])["host"]` returns with nothing, since parse_url only works when theres a valid scheme.
Change what exists into 
`if (parse_url($instance)["host"] == $_SERVER['HTTP_HOST'])`
and we have gotten rid of this warning `PHP Warning:  Undefined array key "host"`

<hr/>

[misc/tools.php](https://github.com/dehlirious/LibreY/commit/63921152528d1c4bd7888427e1b8990f9b6f7956#diff-2396f8b1d485d6d2c84d22d3ce0da412f200f98ce3150a395e82b689d219bea1)
Fixed `Undefined array key "host"` / `Undefined array key "scheme"` in get_base_url and implemented a stack trace function, for future implementation/debugging.

<hr/>

Edit: One more fix. [engines/invidious/video.php](https://github.com/dehlirious/LibreY/commit/2b62e16aee69bcff021c5a1482d9670dfee33cc9#diff-785c45f2186ac5c63d23279cdf68c935b3404ebf72f0114d574a4de75556a694)
I do not know the root cause, but when searching for a video, the very last result is completely null. 
This lead to several PHP warnings and a fatal error, causing the footer to not show.

I still have the issue of no thumbnails showing, but that is because the domain used to get the thumbnail is not in `allowed_domains` in image_proxy.php , but that fix is for a later time.
(config says invidious.snopyta.org, yet thumbnails are loaded via inv.owo.si)

Right now what I've done is changed 
`$json_response = json_decode($response, true) ?? [];` <- to ensure that $json_response is never null
`PHP Warning:  foreach() argument must be of type array|object, null given`

And  implemented a fallback blank value if null like ` $title = $result["title"] ?? '';`
`PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string`

Still have the odd blank result at the very end though!
![Capture](https://github.com/Ahwxorg/LibreY/assets/25449483/8c1eacee-15e2-459c-a151-afb7ecd167ee)


Personally--- I think this logic should be adapted for youtube thumbnails.

```
$video_link = $_GET['vurl'];

$pattern = '/(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([^\s]+)/';
$replacement = 'https://i.ytimg.com/vi/$1/maxresdefault.jpg';

$thumbnail = preg_replace($pattern, $replacement, $video_link);
```

This approach skips the middleman and proxies YouTube thumbnails directly. I've already implemented it on [this](https://github.com/dehlirious/LibreY/tree/img_proxy) branch, so no additional work is needed from your side. It's up to you whether to implement it.