### PR TITLE
Direct YouTube thumbnail image proxying

### DIFF
--- a/engines/invidious/video.php
+++ b/engines/invidious/video.php
@@ -41,7 +41,8 @@
         public static function print_results($results, $opts) {
             echo "<div class=\"text-result-container\">";
 
-            foreach ($results as $result) {
+            foreach ($results as $key => $result) {
+                if ($key == "results_source") continue;
                 $title = $result["title"] ?? '';
                 $url = $result["url"] ?? '';
                 $url = check_for_privacy_frontend($url, $opts);

--- a/engines/invidious/video.php
+++ b/engines/invidious/video.php
@@ -9,9 +9,9 @@
 
         public function parse_results($response) {
             $results = array();
-            $json_response = json_decode($response, true) ?? [];
+            $json_response = json_decode($response, true);
 
-            foreach ($json_response as $response) {
+            foreach ($json_response ?: [] as $response) {
                 if ($response["type"] == "video") {
                     $title = $response["title"];
                     $url = "https://youtube.com/watch?v=" . $response["videoId"];
@@ -49,7 +49,7 @@
                 $uploader = $result["uploader"] ?? '';
                 $views = $result["views"] ?? '';
                 $date = $result["date"] ?? '';
-                $thumbnail = $result["thumbnail"] ?? '';
+                $thumbnail = preg_replace('/(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([^\s]+)/', 'https://i.ytimg.com/vi/$1/maxresdefault.jpg', $url) ?? '';
 
                 echo "<div class=\"text-result-wrapper\">";
                 echo "<a href=\"$url\">";

--- a/image_proxy.php
+++ b/image_proxy.php
@@ -6,7 +6,7 @@
     $url = $_REQUEST["url"];
     $requested_root_domain = get_root_domain($url);
 
-    $allowed_domains = array("s2.qwant.com", "s1.qwant.com", "upload.wikimedia.org", get_root_domain($config->invidious_instance_for_video_results));
+    $allowed_domains = array("i.ytimg.com", "s2.qwant.com", "s1.qwant.com", "upload.wikimedia.org", get_root_domain($config->invidious_instance_for_video_results));
 
     if (in_array($requested_root_domain, $allowed_domains))
     {


### PR DESCRIPTION
Rather than proxying the image from the instance where the YouTube results are pulled from, 

Let's directly proxy the YouTube video thumbnail straight from i.ytimg.com!

This PR also includes a fix for the 'blank result' at the end of the video results!