### PR TITLE
image_proxy.php: remove invidious from allowed domains

### DIFF
--- a/image_proxy.php
+++ b/image_proxy.php
@@ -6,7 +6,7 @@
     $url = $_REQUEST["url"];
     $requested_root_domain = get_root_domain($url);
 
-    $allowed_domains = array("i.ytimg.com", "s2.qwant.com", "s1.qwant.com", "upload.wikimedia.org", get_root_domain($config->invidious_instance_for_video_results));
+    $allowed_domains = array("i.ytimg.com", "s2.qwant.com", "s1.qwant.com", "upload.wikimedia.org");
 
     if (in_array($requested_root_domain, $allowed_domains))
     {


### PR DESCRIPTION
As of commit c24807eb367ee676cc02612c7f9b92950da4b70a, the Invidious instance is no longer used for fetching thumbnails and should be removed from the list of allowed domains in the image proxy.