### PR TITLE
Missing variable declaration

### DIFF
--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -4,7 +4,7 @@
     }
 
     class TextSearch extends EngineRequest {
-        protected $engine, $engine_request, $special_request;
+        protected $cache_key, $engine, $engines, $engine_request, $special_request;
         public function __construct($opts, $mh) {
             $this->engines = get_engines();
             shuffle($this->engines);


### PR DESCRIPTION
There is a property you are trying to set which isn't declared in the class or any of its parents.

`
Creation of dynamic property TextSearch::$engines is deprecated in /engines/text/text.php on line 9; 
Creation of dynamic property TextSearch::$cache_key is deprecated in /engines/text/text.php on line 13; 
`

Solution: Declare variables before assigning value.

`protected $cache_key, $engine, $engines, $engine_request, $special_request;`