### PR TITLE
Fix for being unable to add as search engine on moz based browsers

### DIFF
--- a/opensearch.xml.example
+++ b/opensearch.xml.example
@@ -7,5 +7,5 @@
   <Url rel="results" type="text/html" method="get" template="http://localhost:80/search.php?q={searchTerms}" />
   <Url type="application/opensearchdescription+xml"
       rel="self"
-      template="/opensearch.xml?method=GET" />
+      template="http://localhost:80/opensearch.xml?method=GET" />
 </OpenSearchDescription>


### PR DESCRIPTION

Fix for this( #128 ) issue 


Installed the Mozilla based LibreWolf browser, looked at a working instance `https://mycroftproject.com/opensearch.xml?method=POST`

The fix for the issue of not being able to add as search engine ended up being:

`  <Url type="application/opensearchdescription+xml" rel="self" template="/opensearch.xml"/>`

Needs to be 

`  <Url type="application/opensearchdescription+xml" rel="self" template="https://localhost:80/opensearch.xml"/>`

Additionally,

<details>

[https://developer.mozilla.org/en-US/docs/Web/OpenSearch](https://developer.mozilla.org/en-US/docs/Web/OpenSearch)

`<Developer>LibreY</Developer>` wouldn't hurt, but is needless.
`<Image width="16" height="16">` is cool
 - `For icons loaded remotely (that is, from https:// URLs as opposed to data: URLs), Firefox will reject icons larger than 10 kilobytes.`
 
 `The xmlns attribute is important — without it you could get the error message "Firefox could not download the search plugin".`
 - i debated adding `xmlns:moz="http://www.mozilla.org/2006/browser/search/"` 

</details>