### PR TITLE
fix: docker-compose.yml: `version` is obsolete, maintenance: docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,13 @@ services:
       - CONFIG_GOOGLE_DOMAIN=com
       - CONFIG_LANGUAGE=en
       - CONFIG_NUMBER_OF_RESULTS=10
-      - CONFIG_INVIDIOUS_INSTANCE=https://invidious.snopyta.org
+      - CONFIG_INVIDIOUS_INSTANCE=https://yt.ahwx.org
       - CONFIG_DISABLE_BITTORRENT_SEARCH=false
       - CONFIG_HIDDEN_SERVICE_SEARCH=false
       - CONFIG_INSTANCE_FALLBACK=true
       - CONFIG_RATE_LIMIT_COOLDOWN=25
       - CONFIG_CACHE_TIME=20
+      - CONFIG_DISABLE_API=false
       - CONFIG_TEXT_SEARCH_ENGINE=auto
       - CURLOPT_PROXY_ENABLED=false
       - CURLOPT_PROXY=192.0.2.53:8388
@@ -22,8 +23,8 @@ services:
       - CURLOPT_USERAGENT=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:116.0) Gecko/20100101 Firefox/116.0
       - CURLOPT_FOLLOWLOCATION=true
     volumes:
-      - ./nginx_logs:/var/log/nginx
-      - ./php_logs:/var/log/php83
+      # - ./nginx_logs:/var/log/nginx # Disabled by default. These are the NGINX request logs.
+      - ./php_logs:/var/log/php83 # Enabled by default. These are the PHP error logs.
     restart: unless-stopped
   watchtower: # Watchtower is not required but highly recommended, since Watchtower will re-pull and restart the LibreY container automatically whenever there's an update.
     image: containrrr/watchtower

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   librey:
     image: ghcr.io/ahwxorg/librey:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,7 +21,6 @@ Dockerized LibreY is a simple way to host LibreY with a view to privacy. If you 
 ### Running a Docker container with Docker Compose
 
 ```yml
-version: "3"
 services:
   librey:
     image: ghcr.io/ahwxorg/librey:latest


### PR DESCRIPTION
After recently updating Docker compose to `2.25.0-1~debian.12~bookworm` from the [official Docker APT repository](https://docs.docker.com/engine/install/debian/#install-using-the-repository), I get this warning after trying to pull the latest Docker image via compose:
```sh
# cd /opt/docker/librey && docker compose pull
WARN[0000] /opt/docker/librey/docker-compose.yml: `version` is obsolete
[+] Pulling 1/1
 ✔ librey Pulled                                                           1.1s

```
Here are the relevant `dpkg.log` lines for my upgrade.
```sh
# cat /var/log/dpkg.log | grep "docker" | grep "upgrade"
2024-03-20 00:00:34 upgrade docker-buildx-plugin:amd64 0.13.0-1~debian.12~bookworm 0.13.1-1~debian.12~bookworm
2024-03-20 00:00:39 upgrade docker-ce-cli:amd64 5:25.0.4-1~debian.12~bookworm 5:25.0.5-1~debian.12~bookworm
2024-03-20 00:00:41 upgrade docker-ce:amd64 5:25.0.4-1~debian.12~bookworm 5:25.0.5-1~debian.12~bookworm
2024-03-20 00:00:47 upgrade docker-ce-rootless-extras:amd64 5:25.0.4-1~debian.12~bookworm 5:25.0.5-1~debian.12~bookworm
2024-03-20 00:00:48 upgrade docker-compose-plugin:amd64 2.24.7-1~debian.12~bookworm 2.25.0-1~debian.12~bookworm
2024-03-21 00:00:20 upgrade docker-ce-cli:amd64 5:25.0.5-1~debian.12~bookworm 5:26.0.0-1~debian.12~bookworm
2024-03-21 00:00:21 upgrade docker-ce:amd64 5:25.0.5-1~debian.12~bookworm 5:26.0.0-1~debian.12~bookworm
2024-03-21 00:00:24 upgrade docker-ce-rootless-extras:amd64 5:25.0.5-1~debian.12~bookworm 5:26.0.0-1~debian.12~bookworm

```

According to the [compose spec](https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md#version-top-level-element), the `version` property was only ever used for backwards-compatibility for very old versions of compose and isn't actually used for anything, since it checks for invalid/newer properties anyway. It has now been deprecated since the Docker compose version mentioned above.

The first commit removed the `version` property. The second commit makes sure the same versions of `docker-compose.yml` are used in `/docker-compose.yml` and `/docker/README.md`.