### PR TITLE
fix(i18n): missing string in Italian and French locales

### DIFF
--- a/locale/fr.php
+++ b/locale/fr.php
@@ -24,6 +24,7 @@ return array(
 
     "settings_title" => "Paramètres",
     "settings_theme" => "Thème",
+    "settings_special_warning" => "Cette case à cocher va durer jusqu'à le bouton de 'Réinitialiser' c'est cliqué ou tes cookies sont dégagés.",
     "settings_special_disabled" => "Désactiver les requêtes spéciaux (par ex. : conversion de la monnaie)",
 
     "settings_frontends" => "Front-ends d'utilisateurs font pour intimité",

--- a/locale/it.php
+++ b/locale/it.php
@@ -24,6 +24,7 @@ return array(
 
     "settings_title" => "Impostazioni",
     "settings_theme" => "Tema",
+    "settings_special_warning" => "Questa casella di spunta persisterà fino a il bottone di 'Ripristina' è cliccato o i tui cookies sono sgombrati.",
     "settings_special_disabled" => "Disabilitare le ricerche speciali (ad es.: conversione di valuta)",
 
     "settings_frontends" => "Intermediari che rispettano la privacy",


### PR DESCRIPTION
This also has to be done for:

- - [ ] Croatian (@SectorV5)
- - [ ] Serbian (@SectorV5)
- - [ ] Korean (@NoaHimesaka1873)
- - [ ] Swedish (@norrlandxyz)