### PR TITLE
Add initial Bing support

### DIFF
--- a/engines/text/bing.php
+++ b/engines/text/bing.php
@@ -57,6 +57,9 @@
                 } else
                     $url = $possible_url;
 
+                if (str_starts_with($url, "a1")) 
+                  continue; // It's probably a Bing-relative link such as for video, skip it. 
+
                 if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
                     continue;
 

--- a/engines/text/bing.php
+++ b/engines/text/bing.php
@@ -53,7 +53,7 @@
                     // Base64 "coded", extract and decode
                     $possible_url = str_replace('-', '+', $possible_url);
                     $possible_url = str_replace('_', '/', $possible_url);
-                    $url = base64_decode($possible_url, true);
+                    $url = urldecode(base64_decode($possible_url, true));
                 } else
                     $url = $possible_url;
 

--- a/engines/text/bing.php
+++ b/engines/text/bing.php
@@ -1,0 +1,89 @@
+<?php
+    class BingSearchRequest extends EngineRequest {
+        public function get_request_url() {
+            $query_encoded = str_replace("%22", "\"", urlencode($this->query));
+
+            $results_language = $this->opts->language;
+            $number_of_results = $this->opts->number_of_results;
+
+            // TODO figure out how to not autocorrect
+            $url = "https://www.bing.com/search?q=$query_encoded&first=" . ((10 * $this->page) + 1);
+
+            // TODO language setting
+            if (!is_null($results_language))
+                $url .= "&lang=$results_language";
+
+            return $url;
+        }
+
+        public function parse_results($response) {
+            $results = array();
+            $xpath = get_xpath($response);
+
+            if (!$xpath)
+                return $results;
+
+            foreach($xpath->query("//ol[@id='b_results']//li") as $result) {
+                $href_url = $xpath->evaluate(".//h2//a//@href", $result)[0];
+
+                if ($href_url == null)
+                    continue;
+
+                $possible_url = $href_url->textContent;
+
+                $possible_url_query = parse_url($possible_url, PHP_URL_QUERY);
+
+                if ($possible_url_query == false)
+                    continue;
+
+                parse_str($possible_url_query, $possible_url);
+
+                if (!array_key_exists('u', $possible_url))
+                    continue;
+
+                $possible_url = $possible_url['u'];
+                
+                if (str_starts_with($possible_url, "a1aHR0c"))
+                {
+                    // First two characters are irrelevant, strip for later
+                    $possible_url = substr($possible_url, 2);
+                }
+                if (str_starts_with($possible_url, "aHR0c"))
+                {
+                    // Base64 "coded", extract and decode
+                    $possible_url = str_replace('-', '+', $possible_url);
+                    $possible_url = str_replace('_', '/', $possible_url);
+                    $url = base64_decode($possible_url, true);
+                } else
+                    $url = $possible_url;
+
+                if (!empty($results) && array_key_exists("url", $results) && end($results)["url"] == $url->textContent)
+                    continue;
+
+                $title = $xpath->evaluate(".//h2//a", $result)[0];
+
+                if ($title == null)
+                    continue;
+
+                $title = $title->textContent;
+
+                $description = ($xpath->evaluate(".//div[contains(@class, 'b_caption')]//p", $result)[0] ?? null) ?->textContent ?? '';
+
+                array_push($results,
+                    array (
+                        "title" => htmlspecialchars($title),
+                        "url" =>  htmlspecialchars($url),
+                        // base_url is to be removed in the future, see #47
+                        "base_url" => htmlspecialchars(get_base_url($url)),
+                        "description" =>  $description == null ?
+                                          TEXTS["result_no_description"] :
+                                          htmlspecialchars($description)
+                    )
+                );
+
+            }
+           return $results;
+        }
+
+    }
+?>

--- a/engines/text/text.php
+++ b/engines/text/text.php
@@ -1,6 +1,6 @@
 <?php
     function get_engines() {
-        return array("google", "duckduckgo", "brave", "yandex", "ecosia", "mojeek");
+        return array("google", "duckduckgo", "brave", "yandex", "ecosia", "mojeek", "bing");
     }
 
     class TextSearch extends EngineRequest {
@@ -86,6 +86,11 @@
             if ($engine == "mojeek") {
                 require_once "engines/text/mojeek.php";
                 return new MojeekSearchRequest($opts, $mh);
+            }
+
+            if ($engine == "bing") {
+                require_once "engines/text/bing.php";
+                return new BingSearchRequest($opts, $mh);
             }
 
             // if an invalid engine is selected, don't give any results


### PR DESCRIPTION
Note, Bing obfuscates anchor links but it was trivial to determine how to decode them. This has been **working for well over a year as a Greasemonkey script** so I figured I'd provide LibreY support.

Initially Bing simply base64 encoded the URLs (note, specifically with **base64url**, not regular *base64*) but then they began adding two characters before it. While I've never known what they were they've proven to not be needed.

It works in the search and API. I *think* I've gotten the pagination correct? (Page 0 is Bing Page 1 (no selection), Page 1 is Bing Page 11, Page 2 is Bing Page 21, etc...)