### PR TITLE
Update instances.json - update location of my instance

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -92,10 +92,10 @@
       "librey": true
     },
     {
-      "clearnet": "https://libre.blitzw.in/",
+      "clearnet": "https://search.blitzw.in/",
       "tor": null,
       "i2p": null,
-      "country": "ZA",
+      "country": "DE",
       "librey": true
     },
     {


### PR DESCRIPTION
My instance had shamefully been retired for a while, but I came back to it after deciding to conserve memory on my server and updated the instances.json accordingly.

It's now at the URL search.blitzw.in. If you'd like to note, it's protected by Anubis to prevent scraping, which requires javascript.